### PR TITLE
Events – LexerInitialized Domain Event (#8)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,7 +3,7 @@
 # *** exports
 
 # ** app
-from .events import DomainEvent, TiferetError, ExtractText
+from .events import DomainEvent, TiferetError, ExtractText, LexerInitialized
 from .interfaces import LexerService
 from .utils import TiferetLexer
 

--- a/src/events/__init__.py
+++ b/src/events/__init__.py
@@ -4,4 +4,4 @@
 
 # ** app
 from .settings import DomainEvent, TiferetError, a
-from .scan import ExtractText
+from .scan import ExtractText, LexerInitialized

--- a/src/events/scan.py
+++ b/src/events/scan.py
@@ -141,3 +141,47 @@ class ExtractText(DomainEvent):
 
         # Return the extracted blocks.
         return blocks
+
+
+# ** event: lexer_initialized
+class LexerInitialized(DomainEvent):
+    '''
+    Validation gate event that verifies extracted text blocks are
+    non-empty and suitable for lexical analysis.
+    '''
+
+    # * method: execute
+    @DomainEvent.parameters_required(['text_blocks'])
+    def execute(self,
+            text_blocks: List[Dict[str, Any]],
+            **kwargs,
+        ) -> List[Dict[str, Any]]:
+        '''
+        Validate that text blocks are non-empty and contain text.
+
+        :param text_blocks: The list of text block dicts from ExtractText.
+        :type text_blocks: List[Dict[str, Any]]
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The validated text blocks, unchanged.
+        :rtype: List[Dict[str, Any]]
+        '''
+
+        # Verify the blocks list is non-empty.
+        self.verify(
+            expression=len(text_blocks) > 0,
+            error_code='TEXT_EXTRACTION_FAILED',
+            message='No text blocks provided for lexer initialization.',
+        )
+
+        # Verify each block has non-empty text.
+        for block in text_blocks:
+            self.verify(
+                expression=bool(block.get('text', '').strip()),
+                error_code='TEXT_EXTRACTION_FAILED',
+                message=f'Empty text block: {block.get("name", "unknown")}.',
+                block_name=block.get('name', 'unknown'),
+            )
+
+        # Return the validated blocks.
+        return text_blocks


### PR DESCRIPTION
## Summary
Implements the `LexerInitialized` domain event — the second event in the scanner pipeline, acting as a validation gate between text extraction and tokenization.

### Changes
- **`src/events/scan.py`** — `LexerInitialized(DomainEvent)` class: stateless validation gate that verifies text blocks list is non-empty and each block contains non-whitespace text. Returns blocks unchanged on success.
- **`src/events/tests/test_scan.py`** — 4 tests: success, missing param, empty blocks, empty text. Added `sample_text_blocks` fixture.
- **`src/events/__init__.py`** — Added `LexerInitialized` export.
- **`src/__init__.py`** — Added `LexerInitialized` export.

### Testing
All 46 tests pass (37 lexer + 5 ExtractText + 4 LexerInitialized).

Closes #8

Co-Authored-By: Warp <agent@warp.dev>