### PR TITLE
Events – PerformLexicalAnalysis Domain Event (#9)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,7 +3,7 @@
 # *** exports
 
 # ** app
-from .events import DomainEvent, TiferetError, ExtractText, LexerInitialized
+from .events import DomainEvent, TiferetError, ExtractText, LexerInitialized, PerformLexicalAnalysis
 from .interfaces import LexerService
 from .utils import TiferetLexer
 

--- a/src/events/__init__.py
+++ b/src/events/__init__.py
@@ -4,4 +4,4 @@
 
 # ** app
 from .settings import DomainEvent, TiferetError, a
-from .scan import ExtractText, LexerInitialized
+from .scan import ExtractText, LexerInitialized, PerformLexicalAnalysis


### PR DESCRIPTION
## Summary
Implements the `PerformLexicalAnalysis` domain event — the third event in the scanner pipeline and the core analytical step.

### Changes
- **`src/events/scan.py`** — `PerformLexicalAnalysis(DomainEvent)` class: receives `LexerService` via constructor injection, tokenizes all validated blocks, computes 8 domain metrics (commands_detected, execute_methods_found, verify_calls, parameters_required_decorators, service_calls, factory_calls, constants_referenced, docstrings_found) plus top_token_types using `Counter`.
- **`src/events/tests/test_scan.py`** — 2 tests: success (verifies token count, metrics, and service call) and missing param. Added `mock_lexer_service` fixture.
- **`src/events/__init__.py`** — Added `PerformLexicalAnalysis` export.
- **`src/__init__.py`** — Added `PerformLexicalAnalysis` export.

### Testing
All 48 tests pass (37 lexer + 5 ExtractText + 4 LexerInitialized + 2 PerformLexicalAnalysis).

Closes #9

Co-Authored-By: Warp <agent@warp.dev>