### PR TITLE
Events – EmitScanResult Domain Event (#10)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,7 +3,7 @@
 # *** exports
 
 # ** app
-from .events import DomainEvent, TiferetError, ExtractText, LexerInitialized, PerformLexicalAnalysis
+from .events import DomainEvent, TiferetError, ExtractText, LexerInitialized, PerformLexicalAnalysis, EmitScanResult
 from .interfaces import LexerService
 from .utils import TiferetLexer
 

--- a/src/events/__init__.py
+++ b/src/events/__init__.py
@@ -4,4 +4,4 @@
 
 # ** app
 from .settings import DomainEvent, TiferetError, a
-from .scan import ExtractText, LexerInitialized, PerformLexicalAnalysis
+from .scan import ExtractText, LexerInitialized, PerformLexicalAnalysis, EmitScanResult


### PR DESCRIPTION
## Summary
Implements the `EmitScanResult` domain event — the fourth and final event in the scanner pipeline.

### Changes
- **`src/events/scan.py`** — `EmitScanResult(DomainEvent)` class: assembles scan result payload with event metadata (`event_type`, `timestamp`, `source_file`, `token_count`), supports `--summary-only` (omit tokens, include metrics), `--with-metrics` (include both), `extracted_artifacts` list when `-x` used, and file output in YAML/JSON with auto-detection. Includes `_write_output` helper method.
- **`src/events/tests/test_scan.py`** — 6 tests: default output, summary-only, with-metrics, no analysis, YAML write, JSON write. Added `sample_analysis_result` fixture.
- **`src/events/__init__.py`** — Added `EmitScanResult` export.
- **`src/__init__.py`** — Added `EmitScanResult` export.

### Testing
All 54 tests pass (37 lexer + 17 events) — matches the project target.

Closes #10

Co-Authored-By: Warp <agent@warp.dev>