### PR TITLE
Lexer Token Set Evolution

### DIFF
--- a/docs/guides/lexical_spec.md
+++ b/docs/guides/lexical_spec.md
@@ -12,10 +12,9 @@ The dialect is characterized by:
 - Dependency injection via `__init__`
 - A single `execute` method containing ordered business logic
 - Declarative parameter validation via `@DomainEvent.parameters_required([...])`
-- Ubiquitous use of `self.verify(...)`, `self.*_service.*(...)`, domain object factories `*.new(...)`, and domain constants `a.const.*`
 - Standard Python syntax for function signatures, type annotations, calls, lists, dicts, etc.
 
-The scanner is **not** a complete Python lexer — it recognizes only the tokens necessary to identify domain structure, validation patterns, service interactions, and execution flow for later AST-based extraction.
+The scanner is **not** a complete Python lexer — it recognizes only the tokens necessary to identify domain structure, annotation markers, operators, and execution flow for later AST-based extraction.
 
 
 ## Token Categories/Types
@@ -28,37 +27,56 @@ The scanner is **not** a complete Python lexer — it recognizes only the tokens
 - ARTIFACT_SECTION       `# ** …`      (subsections: event names, import groups)
 - ARTIFACT_MEMBER        `# * …`       (members: method: execute, attribute: xxx_service)
 
+### Annotation Markers
+
+- OBSOLETE               `# - obsolete: …` or `# -- obsolete: …`  (marks deprecated artifact members)
+- TODO                   `# + todo: …` or `# ++ todo: …`           (marks in-progress artifact members)
+
 ### Documentation & Conventional Comments
 
 - DOCSTRING              Triple-quoted string literals used as class/method docstrings
-- LINE_COMMENT           Single-line `# …` comments not matching artifact patterns
+- LINE_COMMENT           Single-line `# …` comments not matching artifact or annotation patterns
 
-### Control & Structural Keywords (Tiferet-specific high-value names)
+### Control & Structural Keywords
 
 - CLASS                  `class`
 - DEF                    `def`
 - INIT                   `__init__`     (dependency injection point)
-- EXECUTE                `execute`     (the core business method)
 - RETURN                 `return`
 
 ### Self Reference
 
 - SELF                   `self`
 
-### Domain Idioms & Patterns (core semantic carriers)
-
-- PARAMETERS_REQUIRED    `@DomainEvent.parameters_required(`  (declarative parameter validation decorator)
-- VERIFY                 `self.verify(`
-- SERVICE_CALL           `self.<ident>_service.<ident>(`   (service method invocation)
-- FACTORY_CALL           `<ident>.new(`                    (domain factory invocation)
-- CONST_REF              `a.const.<ident>`
-
 ### Generic Python Structural Tokens
 
 - PYTHON_KEYWORD         Python reserved words: `from`, `import`, `if`, `else`, `for`, `True`, `False`, `None`, `is`, `not`, `in`, `and`, `or`, `as`, `with`, etc.
 - IDENTIFIER             Letter/_ followed by letters/digits/_
 - STRING_LITERAL         `'…'`, `"…"`, `'''…'''`, `"""…"""`
-- NUMBER_LITERAL         Integer, float, or simple scientific notation
+- NUMBER_LITERAL         Integer or float
+
+### Operators
+
+- DOUBLESTAR             `**`
+- PLUS                   `+`
+- MINUS                  `-`
+- STAR                   `*`
+- SLASH                  `/`
+- DOUBLESLASH            `//`
+- PERCENT                `%`
+- PIPE                   `|`
+- AMPERSAND              `&`
+- TILDE                  `~`
+- CARET                  `^`
+- LSHIFT                 `<<`
+- RSHIFT                 `>>`
+- EQEQ                   `==`
+- NOTEQ                  `!=`
+- LTEQ                   `<=`
+- GTEQ                   `>=`
+- LT                     `<`
+- GT                     `>`
+- AT                     `@`
 
 ### Punctuation & Delimiters
 
@@ -93,23 +111,24 @@ ARTIFACT_SECTION        #\s*\*{2}\s+.*
 ARTIFACT_MEMBER         #\s*\*\s+.*
 ```
 
+### Annotation Markers
+```
+OBSOLETE                #\s*-{1,2}\s+obsolete:[^\n]+
+TODO                    #\s*\+{1,2}\s+todo:[^\n]+
+```
+
 ### Documentation & Comments
 ```
 DOCSTRING               (""".*?""")
 LINE_COMMENT            #.*$                        (not starting with * after #)
 ```
 
-### Structural & Domain Keywords (longest match first)
+### Structural Keywords
 ```
 CLASS                   class
 DEF                     def
 INIT                    __init__
 RETURN                  return
-PARAMETERS_REQUIRED     @DomainEvent\.parameters_required\(
-VERIFY                  self\.verify\(
-SERVICE_CALL            self\.[a-zA-Z_][a-zA-Z0-9_]*_service\.[a-zA-Z_][a-zA-Z0-9_]*\(
-FACTORY_CALL            [a-zA-Z_][a-zA-Z0-9_]*\.new\(
-CONST_REF               a\.const\.[A-Z_][A-Z_]*
 SELF                    self
 ```
 
@@ -121,7 +140,31 @@ STRING_LITERAL          ("([^"\\]|\\.)*")|('([^'\\]|\\.)*')|('''.*?''')
 NUMBER_LITERAL          [0-9]+(\.[0-9]+)?
 ```
 
-### Punctuation & Delimiters (single characters / short fixed strings)
+### Operators (longest match first)
+```
+DOUBLESTAR              \*\*
+DOUBLESLASH             //
+LSHIFT                  <<
+RSHIFT                  >>
+EQEQ                    ==
+NOTEQ                   !=
+LTEQ                    <=
+GTEQ                    >=
+PLUS                    \+
+MINUS                   -
+STAR                    \*
+SLASH                   /
+PERCENT                 %
+PIPE                    \|
+AMPERSAND               &
+TILDE                   ~
+CARET                   \^
+LT                      <
+GT                      >
+AT                      @
+```
+
+### Punctuation & Delimiters
 ```
 LPAREN                  \(
 RPAREN                  \)
@@ -144,7 +187,7 @@ UNKNOWN                 .
 
 **Ignored characters:** spaces and tabs (`t_ignore = ' \t'`).
 
-**Note:** The lexer uses longest-match-first priority and prefers domain-specific patterns (PARAMETERS_REQUIRED, SERVICE_CALL, etc.) over generic IDENTIFIER or PYTHON_KEYWORD.
+**Note:** Multi-character operators (`**`, `//`, `<<`, `>>`, `==`, `!=`, `<=`, `>=`) use longest-match-first priority over their single-character counterparts.
 
 ### Keyword Resolution Rules
 
@@ -153,7 +196,6 @@ When the lexer matches an `IDENTIFIER` pattern (`[a-zA-Z_][a-zA-Z0-9_]*`), it ch
 - `class` → `CLASS`
 - `def` → `DEF`
 - `__init__` → `INIT`
-- `execute` → `EXECUTE`
 - `return` → `RETURN`
 - `self` → `SELF`
 - Any Python reserved word (`from`, `import`, `if`, `else`, `for`, `True`, `False`, `None`, `is`, `not`, `in`, `and`, `or`, `as`, `with`, `yield`, etc.) → `PYTHON_KEYWORD`
@@ -182,6 +224,17 @@ from ..mappers import ErrorAggregate
 class AddError(DomainEvent):
 ```
 
+### Annotation Markers
+```python
+# -- obsolete: replaced by ErrorAggregate.new in v0.2.0
+def _build_error(self, id, name):
+    ...
+
+# ++ todo: inject CacheService for result caching
+def execute(self, id: str, **kwargs):
+    ...
+```
+
 ### Class & Method Structure
 ```python
 class AddError(DomainEvent):
@@ -190,26 +243,6 @@ class AddError(DomainEvent):
 
     @DomainEvent.parameters_required(['id', 'name', 'message'])
     def execute(self, id: str, name: str, message: str, **kwargs) -> None:
-```
-
-### Domain Idioms & Validation
-```python
-    @DomainEvent.parameters_required(['id', 'name', 'message'])
-    def execute(self, id: str, name: str, message: str, **kwargs):
-
-        exists = self.error_service.exists(id)
-        self.verify(
-            expression=exists is False,
-            error_code=a.const.ERROR_ALREADY_EXISTS_ID,
-            message=f'An error with ID {id} already exists.'
-        )
-```
-
-### Factory & Return
-```python
-        new_error = Aggregate.new(ErrorAggregate, id=id, name=name, message=error_messages)
-        self.error_service.save(new_error)
-        return new_error
 ```
 
 ### Type Annotations & Collections

--- a/src/assets/lexer.py
+++ b/src/assets/lexer.py
@@ -22,6 +22,12 @@ ARTIFACT_SECTION = 'ARTIFACT_SECTION'
 # ** constant: artifact_member
 ARTIFACT_MEMBER = 'ARTIFACT_MEMBER'
 
+# ** constant: obsolete
+OBSOLETE = 'OBSOLETE'
+
+# ** constant: todo
+TODO = 'TODO'
+
 # ** constant: docstring
 DOCSTRING = 'DOCSTRING'
 
@@ -54,6 +60,66 @@ STRING_LITERAL = 'STRING_LITERAL'
 
 # ** constant: number_literal
 NUMBER_LITERAL = 'NUMBER_LITERAL'
+
+# ** constant: doublestar
+DOUBLESTAR = 'DOUBLESTAR'
+
+# ** constant: plus
+PLUS = 'PLUS'
+
+# ** constant: minus
+MINUS = 'MINUS'
+
+# ** constant: star
+STAR = 'STAR'
+
+# ** constant: slash
+SLASH = 'SLASH'
+
+# ** constant: doubleslash
+DOUBLESLASH = 'DOUBLESLASH'
+
+# ** constant: percent
+PERCENT = 'PERCENT'
+
+# ** constant: pipe
+PIPE = 'PIPE'
+
+# ** constant: ampersand
+AMPERSAND = 'AMPERSAND'
+
+# ** constant: tilde
+TILDE = 'TILDE'
+
+# ** constant: caret
+CARET = 'CARET'
+
+# ** constant: lshift
+LSHIFT = 'LSHIFT'
+
+# ** constant: rshift
+RSHIFT = 'RSHIFT'
+
+# ** constant: eqeq
+EQEQ = 'EQEQ'
+
+# ** constant: noteq
+NOTEQ = 'NOTEQ'
+
+# ** constant: lteq
+LTEQ = 'LTEQ'
+
+# ** constant: gteq
+GTEQ = 'GTEQ'
+
+# ** constant: lt
+LT = 'LT'
+
+# ** constant: gt
+GT = 'GT'
+
+# ** constant: at
+AT = 'AT'
 
 # ** constant: lparen
 LPAREN = 'LPAREN'
@@ -102,6 +168,8 @@ TOKENS = (
     ARTIFACT_START,
     ARTIFACT_SECTION,
     ARTIFACT_MEMBER,
+    OBSOLETE,
+    TODO,
 
     # Documentation & comments
     DOCSTRING,
@@ -121,6 +189,28 @@ TOKENS = (
     IDENTIFIER,
     STRING_LITERAL,
     NUMBER_LITERAL,
+
+    # Operators
+    DOUBLESTAR,
+    PLUS,
+    MINUS,
+    STAR,
+    SLASH,
+    DOUBLESLASH,
+    PERCENT,
+    PIPE,
+    AMPERSAND,
+    TILDE,
+    CARET,
+    LSHIFT,
+    RSHIFT,
+    EQEQ,
+    NOTEQ,
+    LTEQ,
+    GTEQ,
+    LT,
+    GT,
+    AT,
 
     # Punctuation & delimiters
     LPAREN,
@@ -174,6 +264,16 @@ def ARTIFACT_MEMBER(self, t):
     r'\#\s*\*\s+.*'
     return t
 
+# ** constant: obsolete
+def OBSOLETE(self, t):
+    r'\#\s*-{1,2}\s+obsolete:[^\n]+'
+    return t
+
+# ** constant: todo
+def TODO(self, t):
+    r'\#\s*\+{1,2}\s+todo:[^\n]+'
+    return t
+
 # ** constant: docstring
 def DOCSTRING(self, t):
     r'(\"\"\"[\s\S]*?\"\"\"|\'\'\'[\s\S]*?\'\'\')'
@@ -225,6 +325,66 @@ def IDENTIFIER(self, t):
 
     return t
 
+# ** constant: doublestar
+DOUBLESTAR = r'\*\*'
+
+# ** constant: doubleslash
+DOUBLESLASH = r'//'
+
+# ** constant: lshift
+LSHIFT = r'<<'
+
+# ** constant: rshift
+RSHIFT = r'>>'
+
+# ** constant: eqeq
+EQEQ = r'=='
+
+# ** constant: noteq
+NOTEQ = r'!='
+
+# ** constant: lteq
+LTEQ = r'<='
+
+# ** constant: gteq
+GTEQ = r'>='
+
+# ** constant: plus
+PLUS = r'\+'
+
+# ** constant: minus
+MINUS = r'-'
+
+# ** constant: star
+STAR = r'\*'
+
+# ** constant: slash
+SLASH = r'/'
+
+# ** constant: percent
+PERCENT = r'%'
+
+# ** constant: pipe
+PIPE = r'\|'
+
+# ** constant: ampersand
+AMPERSAND = r'&'
+
+# ** constant: tilde
+TILDE = r'~'
+
+# ** constant: caret
+CARET = r'\^'
+
+# ** constant: lt
+LT = r'<'
+
+# ** constant: gt
+GT = r'>'
+
+# ** constant: at
+AT = r'@'
+
 # ** constant: lparen
 LPAREN = r'\('
 
@@ -268,12 +428,34 @@ RULES = {
     't_ARTIFACT_START': ARTIFACT_START,
     't_ARTIFACT_SECTION': ARTIFACT_SECTION,
     't_ARTIFACT_MEMBER': ARTIFACT_MEMBER,
+    't_OBSOLETE': OBSOLETE,
+    't_TODO': TODO,
     't_DOCSTRING': DOCSTRING,
     't_LINE_COMMENT': LINE_COMMENT,
     't_STRING_LITERAL': STRING_LITERAL,
     't_ARROW': ARROW,
     't_NUMBER_LITERAL': NUMBER_LITERAL,
     't_IDENTIFIER': IDENTIFIER,
+    't_DOUBLESTAR': DOUBLESTAR,
+    't_DOUBLESLASH': DOUBLESLASH,
+    't_LSHIFT': LSHIFT,
+    't_RSHIFT': RSHIFT,
+    't_EQEQ': EQEQ,
+    't_NOTEQ': NOTEQ,
+    't_LTEQ': LTEQ,
+    't_GTEQ': GTEQ,
+    't_PLUS': PLUS,
+    't_MINUS': MINUS,
+    't_STAR': STAR,
+    't_SLASH': SLASH,
+    't_PERCENT': PERCENT,
+    't_PIPE': PIPE,
+    't_AMPERSAND': AMPERSAND,
+    't_TILDE': TILDE,
+    't_CARET': CARET,
+    't_LT': LT,
+    't_GT': GT,
+    't_AT': AT,
     't_LPAREN': LPAREN,
     't_RPAREN': RPAREN,
     't_LBRACK': LBRACK,

--- a/src/utils/tests/test_lexer.py
+++ b/src/utils/tests/test_lexer.py
@@ -200,6 +200,56 @@ def test_self_reference(lexer: TiferetLexer) -> None:
     assert tok['type'] == 'SELF'
 
 
+# ** test: obsolete_double_dash
+def test_obsolete_double_dash(lexer: TiferetLexer) -> None:
+    '''
+    Test that # -- obsolete:<description> is recognized as OBSOLETE.
+    '''
+
+    tok = first_token(lexer, '# -- obsolete: replaced by new method')
+    assert tok['type'] == 'OBSOLETE'
+
+
+# ** test: obsolete_single_dash
+def test_obsolete_single_dash(lexer: TiferetLexer) -> None:
+    '''
+    Test that # - obsolete:<description> is recognized as OBSOLETE.
+    '''
+
+    tok = first_token(lexer, '# - obsolete: replaced by new method')
+    assert tok['type'] == 'OBSOLETE'
+
+
+# ** test: obsolete_with_trailing_text
+def test_obsolete_with_trailing_text(lexer: TiferetLexer) -> None:
+    '''
+    Test that # -- obsolete with trailing text is recognized as OBSOLETE.
+    '''
+
+    tok = first_token(lexer, '# -- obsolete: replaced by new_method')
+    assert tok['type'] == 'OBSOLETE'
+
+
+# ** test: todo_single_plus
+def test_todo_single_plus(lexer: TiferetLexer) -> None:
+    '''
+    Test that # + todo:<description> is recognized as TODO.
+    '''
+
+    tok = first_token(lexer, '# + todo: add caching support')
+    assert tok['type'] == 'TODO'
+
+
+# ** test: todo_double_plus
+def test_todo_double_plus(lexer: TiferetLexer) -> None:
+    '''
+    Test that # ++ todo:<description> is recognized as TODO.
+    '''
+
+    tok = first_token(lexer, '# ++ todo: add CacheService injection')
+    assert tok['type'] == 'TODO'
+
+
 # ** test: python_keywords
 def test_python_keywords(lexer: TiferetLexer) -> None:
     '''
@@ -263,6 +313,65 @@ def test_number_literal_float(lexer: TiferetLexer) -> None:
     tok = first_token(lexer, '3.14')
     assert tok['type'] == 'NUMBER_LITERAL'
     assert tok['value'] == '3.14'
+
+
+# ** test: operators_arithmetic
+def test_operators_arithmetic(lexer: TiferetLexer) -> None:
+    '''
+    Test that arithmetic operators are recognized correctly.
+    '''
+
+    cases = {
+        '+': 'PLUS',
+        '-': 'MINUS',
+        '*': 'STAR',
+        '/': 'SLASH',
+        '**': 'DOUBLESTAR',
+        '//': 'DOUBLESLASH',
+        '%': 'PERCENT',
+        '@': 'AT',
+    }
+    for char, expected_type in cases.items():
+        tok = first_token(lexer, char)
+        assert tok['type'] == expected_type, f'{char!r} should be {expected_type}, got {tok["type"]}'
+
+
+# ** test: operators_comparison
+def test_operators_comparison(lexer: TiferetLexer) -> None:
+    '''
+    Test that comparison operators are recognized correctly.
+    '''
+
+    cases = {
+        '==': 'EQEQ',
+        '!=': 'NOTEQ',
+        '<': 'LT',
+        '>': 'GT',
+        '<=': 'LTEQ',
+        '>=': 'GTEQ',
+    }
+    for char, expected_type in cases.items():
+        tok = first_token(lexer, char)
+        assert tok['type'] == expected_type, f'{char!r} should be {expected_type}, got {tok["type"]}'
+
+
+# ** test: operators_bitwise
+def test_operators_bitwise(lexer: TiferetLexer) -> None:
+    '''
+    Test that bitwise operators are recognized correctly.
+    '''
+
+    cases = {
+        '|': 'PIPE',
+        '&': 'AMPERSAND',
+        '~': 'TILDE',
+        '^': 'CARET',
+        '<<': 'LSHIFT',
+        '>>': 'RSHIFT',
+    }
+    for char, expected_type in cases.items():
+        tok = first_token(lexer, char)
+        assert tok['type'] == expected_type, f'{char!r} should be {expected_type}, got {tok["type"]}'
 
 
 # ** test: punctuation


### PR DESCRIPTION
## Summary

Implements TRD #20 — expands the lexer token set from 29 to 51 tokens, introduces annotation markers, adds operator coverage, and relocates the lexical specification to `docs/guides/`.

## Changes

### `src/assets/lexer.py`
- Add `OBSOLETE` annotation token (`# - obsolete: …` / `# -- obsolete: …`)
- Add `TODO` annotation token (`# + todo: …` / `# ++ todo: …`)
- Add 20 operator/comparison tokens: `DOUBLESTAR`, `PLUS`, `MINUS`, `STAR`, `SLASH`, `DOUBLESLASH`, `PERCENT`, `PIPE`, `AMPERSAND`, `TILDE`, `CARET`, `LSHIFT`, `RSHIFT`, `EQEQ`, `NOTEQ`, `LTEQ`, `GTEQ`, `LT`, `GT`, `AT`
- Domain idiom tokens (`EXECUTE`, `PARAMETERS_REQUIRED`) are not present — resolved via `IDENTIFIER` fallback
- `TOKENS` tuple updated to 51 entries (no `INDENT`/`DEDENT` — those are TRD #15)
- `RULES` dict updated with all new handlers; multi-char operators ordered before single-char

### `src/utils/tests/test_lexer.py`
- Add 8 new tests: `test_obsolete_double_dash`, `test_obsolete_single_dash`, `test_obsolete_with_trailing_text`, `test_todo_single_plus`, `test_todo_double_plus`, `test_operators_arithmetic`, `test_operators_comparison`, `test_operators_bitwise`
- Total: **43 tests passing**

### `docs/guides/lexical_spec.md` (renamed from `LEXICAL_SPEC.md`)
- Moved to `docs/guides/` directory
- Removed `EXECUTE` from structural keywords
- Removed domain idioms section (`PARAMETERS_REQUIRED`, `VERIFY`, `SERVICE_CALL`, `FACTORY_CALL`, `CONST_REF`)
- Added Annotation Markers section (`OBSOLETE`, `TODO`)
- Added Operators section with formal regex spec
- Updated keyword resolution rules (removed `execute → EXECUTE`)

## Acceptance Criteria
- [x] `TOKENS` contains 51 entries
- [x] `OBSOLETE` and `TODO` handlers defined before `LINE_COMMENT` (PLY priority)
- [x] Multi-char operators match before single-char counterparts
- [x] `docs/guides/lexical_spec.md` exists; root `LEXICAL_SPEC.md` deleted
- [x] 43 `test_lexer.py` tests pass

Closes #20