### PR TITLE
ArtifactBlockParser Utility

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -4,3 +4,4 @@
 
 # ** app
 from .lexer import TiferetLexer
+from .parser import ArtifactBlockParser

--- a/src/utils/parser.py
+++ b/src/utils/parser.py
@@ -1,0 +1,163 @@
+"""Artifact Block Parser Utility"""
+
+# *** imports
+
+# ** core
+import re
+from typing import List, Dict, Any, Set, Optional
+
+# *** utils
+
+# ** util: artifact_block_parser
+class ArtifactBlockParser:
+    '''
+    Utility for parsing Tiferet artifact blocks from source file lines.
+    Extracts imports sections and group-typed artifact blocks
+    (e.g. event, model, context) using the structured comment convention.
+    '''
+
+    # * method: parse_extract_filter (static)
+    @staticmethod
+    def parse_extract_filter(extract: str) -> Optional[Set[str]]:
+        '''
+        Parse a comma-separated extract filter string into a set of names.
+
+        :param extract: Comma-separated artifact names, or None.
+        :type extract: str
+        :return: A set of stripped names, or None if extract is falsy.
+        :rtype: Optional[Set[str]]
+        '''
+
+        # Return None if no filter provided.
+        if not extract:
+            return None
+
+        # Split, strip, and return as a set.
+        return set(name.strip() for name in extract.split(','))
+
+    # * method: extract_imports_block (static)
+    @staticmethod
+    def extract_imports_block(lines: List[str]) -> Optional[Dict[str, Any]]:
+        '''
+        Locate and extract the imports section from source lines.
+        The imports block spans from ``# *** imports`` to the next
+        top-level ``# ***`` section.
+
+        :param lines: The source file lines.
+        :type lines: List[str]
+        :return: A block dict with name, line_start, line_end, text,
+                 and length_chars, or None if not found.
+        :rtype: Optional[Dict[str, Any]]
+        '''
+
+        # Build patterns for imports start and next top-level section.
+        imports_start_pattern = re.compile(r'^\s*#\s*\*{3}\s+imports\s*$')
+        top_level_pattern = re.compile(r'^\s*#\s*\*{3}\s+\S+')
+
+        # Walk lines to find the imports section boundaries.
+        imports_start = None
+
+        for i, line in enumerate(lines):
+            if imports_start is None:
+                if imports_start_pattern.match(line):
+                    imports_start = i
+            elif top_level_pattern.match(line):
+                text = ''.join(lines[imports_start:i])
+                return {
+                    'name': '__imports__',
+                    'line_start': imports_start,
+                    'line_end': i,
+                    'text': text,
+                    'length_chars': len(text),
+                }
+
+        # Return None if no imports section found.
+        return None
+
+    # * method: extract_artifact_blocks (static)
+    @staticmethod
+    def extract_artifact_blocks(
+            lines: List[str],
+            group_type: str = 'event',
+        ) -> List[Dict[str, Any]]:
+        '''
+        Walk source lines and extract all artifact blocks matching
+        the given group type (e.g. ``# ** event: <name>``).
+
+        :param lines: The source file lines.
+        :type lines: List[str]
+        :param group_type: The artifact group type to match.
+        :type group_type: str
+        :return: A list of block dicts with name, line_start, line_end,
+                 text, and length_chars.
+        :rtype: List[Dict[str, Any]]
+        '''
+
+        # Build the section pattern for the given group type.
+        section_pattern = re.compile(
+            rf'^\s*#\s*\*\*\s+{re.escape(group_type)}:\s+(\S+)'
+        )
+
+        # Walk lines to find matching artifact blocks.
+        blocks = []
+        current_block = None
+
+        for i, line in enumerate(lines):
+            match = section_pattern.match(line)
+
+            if match:
+
+                # Close the previous block if open.
+                if current_block is not None:
+                    current_block['line_end'] = i
+                    current_block['text'] = ''.join(
+                        lines[current_block['line_start']:i]
+                    )
+                    current_block['length_chars'] = len(current_block['text'])
+                    blocks.append(current_block)
+
+                # Start a new block.
+                name = match.group(1)
+                current_block = {
+                    'name': name,
+                    'line_start': i,
+                    'line_end': None,
+                    'text': None,
+                    'length_chars': 0,
+                }
+
+        # Close the last block.
+        if current_block is not None:
+            current_block['line_end'] = len(lines)
+            current_block['text'] = ''.join(
+                lines[current_block['line_start']:]
+            )
+            current_block['length_chars'] = len(current_block['text'])
+            blocks.append(current_block)
+
+        # Return the extracted blocks.
+        return blocks
+
+    # * method: filter_blocks (static)
+    @staticmethod
+    def filter_blocks(
+            blocks: List[Dict[str, Any]],
+            extract_ids: Optional[Set[str]],
+        ) -> List[Dict[str, Any]]:
+        '''
+        Apply an extract filter to a list of blocks.
+
+        :param blocks: The artifact blocks to filter.
+        :type blocks: List[Dict[str, Any]]
+        :param extract_ids: Set of artifact names to keep, or None for all.
+        :type extract_ids: Optional[Set[str]]
+        :return: The filtered list of blocks.
+        :rtype: List[Dict[str, Any]]
+        '''
+
+        # Return all blocks if no filter specified.
+        if not extract_ids:
+            return blocks
+
+        # Filter to only blocks whose name is in the extract set.
+        return [b for b in blocks if b['name'] in extract_ids]

--- a/src/utils/tests/test_parser.py
+++ b/src/utils/tests/test_parser.py
@@ -1,0 +1,263 @@
+"""Artifact Block Parser Utility Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..parser import ArtifactBlockParser
+
+# *** fixtures
+
+# ** fixture: sample_lines
+@pytest.fixture
+def sample_lines() -> list:
+    '''
+    Return sample source file lines containing imports and event artifact blocks.
+
+    :return: List of source lines.
+    :rtype: list
+    '''
+
+    content = (
+        '# *** imports\n'
+        '\n'
+        '# ** app\n'
+        'from .settings import DomainEvent\n'
+        '\n'
+        '# *** events\n'
+        '\n'
+        '# ** event: add_item\n'
+        'class AddItem(DomainEvent):\n'
+        '    pass\n'
+        '\n'
+        '# ** event: remove_item\n'
+        'class RemoveItem(DomainEvent):\n'
+        '    pass\n'
+    )
+
+    return content.splitlines(keepends=True)
+
+# *** tests — parse_extract_filter
+
+# ** test: parse_extract_filter_none
+def test_parse_extract_filter_none() -> None:
+    '''
+    Test that None input returns None.
+    '''
+
+    # Parse a None extract value.
+    result = ArtifactBlockParser.parse_extract_filter(None)
+
+    # Assert None is returned.
+    assert result is None
+
+
+# ** test: parse_extract_filter_empty_string
+def test_parse_extract_filter_empty_string() -> None:
+    '''
+    Test that an empty string returns None.
+    '''
+
+    # Parse an empty string.
+    result = ArtifactBlockParser.parse_extract_filter('')
+
+    # Assert None is returned.
+    assert result is None
+
+
+# ** test: parse_extract_filter_single
+def test_parse_extract_filter_single() -> None:
+    '''
+    Test parsing a single artifact name.
+    '''
+
+    # Parse a single name.
+    result = ArtifactBlockParser.parse_extract_filter('add_item')
+
+    # Assert a set with one element.
+    assert result == {'add_item'}
+
+
+# ** test: parse_extract_filter_multiple
+def test_parse_extract_filter_multiple() -> None:
+    '''
+    Test parsing comma-separated artifact names with whitespace.
+    '''
+
+    # Parse multiple names with spacing.
+    result = ArtifactBlockParser.parse_extract_filter('add_item, remove_item , get_item')
+
+    # Assert all names are stripped and present.
+    assert result == {'add_item', 'remove_item', 'get_item'}
+
+# *** tests — extract_imports_block
+
+# ** test: extract_imports_block_found
+def test_extract_imports_block_found(sample_lines: list) -> None:
+    '''
+    Test successful extraction of the imports block.
+
+    :param sample_lines: Sample source lines.
+    :type sample_lines: list
+    '''
+
+    # Extract the imports block.
+    result = ArtifactBlockParser.extract_imports_block(sample_lines)
+
+    # Assert the block was found with expected structure.
+    assert result is not None
+    assert result['name'] == '__imports__'
+    assert result['line_start'] == 0
+    assert '# *** imports' in result['text']
+    assert 'from .settings import DomainEvent' in result['text']
+    assert result['length_chars'] == len(result['text'])
+
+
+# ** test: extract_imports_block_not_found
+def test_extract_imports_block_not_found() -> None:
+    '''
+    Test that lines without an imports section return None.
+    '''
+
+    # Provide lines with no imports section.
+    lines = ['x = 1\n', 'y = 2\n']
+
+    # Extract the imports block.
+    result = ArtifactBlockParser.extract_imports_block(lines)
+
+    # Assert None is returned.
+    assert result is None
+
+# *** tests — extract_artifact_blocks
+
+# ** test: extract_artifact_blocks_events
+def test_extract_artifact_blocks_events(sample_lines: list) -> None:
+    '''
+    Test extraction of event artifact blocks.
+
+    :param sample_lines: Sample source lines.
+    :type sample_lines: list
+    '''
+
+    # Extract event blocks.
+    blocks = ArtifactBlockParser.extract_artifact_blocks(sample_lines, 'event')
+
+    # Assert two event blocks were found.
+    assert len(blocks) == 2
+    assert blocks[0]['name'] == 'add_item'
+    assert blocks[1]['name'] == 'remove_item'
+    assert 'class AddItem' in blocks[0]['text']
+    assert 'class RemoveItem' in blocks[1]['text']
+
+
+# ** test: extract_artifact_blocks_none_matching
+def test_extract_artifact_blocks_none_matching(sample_lines: list) -> None:
+    '''
+    Test extraction with a group type that has no matches.
+
+    :param sample_lines: Sample source lines.
+    :type sample_lines: list
+    '''
+
+    # Extract blocks for a non-existent group type.
+    blocks = ArtifactBlockParser.extract_artifact_blocks(sample_lines, 'model')
+
+    # Assert empty list returned.
+    assert blocks == []
+
+
+# ** test: extract_artifact_blocks_line_boundaries
+def test_extract_artifact_blocks_line_boundaries(sample_lines: list) -> None:
+    '''
+    Test that block line_start and line_end boundaries are correct.
+
+    :param sample_lines: Sample source lines.
+    :type sample_lines: list
+    '''
+
+    # Extract event blocks.
+    blocks = ArtifactBlockParser.extract_artifact_blocks(sample_lines, 'event')
+
+    # Assert first block starts at the event comment line.
+    assert blocks[0]['line_start'] == 7
+
+    # Assert second block starts at its event comment and ends at EOF.
+    assert blocks[1]['line_start'] == 11
+    assert blocks[1]['line_end'] == len(sample_lines)
+
+
+# ** test: extract_artifact_blocks_length_chars
+def test_extract_artifact_blocks_length_chars(sample_lines: list) -> None:
+    '''
+    Test that length_chars matches the actual text length.
+
+    :param sample_lines: Sample source lines.
+    :type sample_lines: list
+    '''
+
+    # Extract event blocks.
+    blocks = ArtifactBlockParser.extract_artifact_blocks(sample_lines, 'event')
+
+    # Assert length_chars matches text length for each block.
+    for block in blocks:
+        assert block['length_chars'] == len(block['text'])
+
+# *** tests — filter_blocks
+
+# ** test: filter_blocks_no_filter
+def test_filter_blocks_no_filter() -> None:
+    '''
+    Test that None filter returns all blocks unchanged.
+    '''
+
+    # Create sample blocks.
+    blocks = [
+        {'name': 'add_item'},
+        {'name': 'remove_item'},
+    ]
+
+    # Filter with None.
+    result = ArtifactBlockParser.filter_blocks(blocks, None)
+
+    # Assert all blocks returned.
+    assert result == blocks
+
+
+# ** test: filter_blocks_with_filter
+def test_filter_blocks_with_filter() -> None:
+    '''
+    Test filtering to a subset of blocks by name.
+    '''
+
+    # Create sample blocks.
+    blocks = [
+        {'name': 'add_item'},
+        {'name': 'remove_item'},
+        {'name': 'get_item'},
+    ]
+
+    # Filter to only add_item and get_item.
+    result = ArtifactBlockParser.filter_blocks(blocks, {'add_item', 'get_item'})
+
+    # Assert only matching blocks returned.
+    assert len(result) == 2
+    assert result[0]['name'] == 'add_item'
+    assert result[1]['name'] == 'get_item'
+
+
+# ** test: filter_blocks_no_match
+def test_filter_blocks_no_match() -> None:
+    '''
+    Test filtering with names that match no blocks.
+    '''
+
+    # Create sample blocks.
+    blocks = [{'name': 'add_item'}]
+
+    # Filter with a name not present.
+    result = ArtifactBlockParser.filter_blocks(blocks, {'nonexistent'})
+
+    # Assert empty list returned.
+    assert result == []


### PR DESCRIPTION
## Summary

Implements TRD #21 — introduces `ArtifactBlockParser`, a static utility class that extracts structured artifact blocks from Python source file lines. Encapsulates the block-parsing logic that currently lives inline in `ExtractText.execute()`, making it independently testable and reusable.

## Changes

### `src/utils/parser.py` (new)
- `ArtifactBlockParser` utility class under `# *** utils` / `# ** util: artifact_block_parser`
- **`parse_extract_filter(extract)`** — parses comma-separated filter string into `Optional[Set[str]]`; returns `None` for falsy input
- **`extract_imports_block(lines)`** — locates `# *** imports` section and returns block dict with `name`, `line_start`, `line_end`, `text`, `length_chars`
- **`extract_artifact_blocks(lines, group_type)`** — extracts all `# ** <type>: <name>` blocks for the given group type
- **`filter_blocks(blocks, extract_ids)`** — applies name-based filter; returns all blocks if `extract_ids` is `None`

### `src/utils/__init__.py`
- Added `from .parser import ArtifactBlockParser` to exports

### `src/utils/tests/test_parser.py` (new)
- 13 tests covering all 4 methods across success, not-found, boundary, and filter cases
- Uses `sample_lines` fixture with imports + 2 event blocks

## Acceptance Criteria
- [x] `ArtifactBlockParser` exported from `src/utils/__init__.py`
- [x] All 4 static methods implemented with correct block dict shape
- [x] 13 tests passing

Closes #21