### PR TITLE
ScanOutputWriter Utility

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -5,3 +5,4 @@
 # ** app
 from .lexer import TiferetLexer
 from .parser import ArtifactBlockParser
+from .output import ScanOutputWriter

--- a/src/utils/output.py
+++ b/src/utils/output.py
@@ -1,0 +1,90 @@
+"""Scan Output Writer Utility"""
+
+# *** imports
+
+# ** core
+import os
+import json
+from typing import Dict, Any, List, Optional
+
+# ** infra
+import yaml
+
+# *** utils
+
+# ** util: scan_output_writer
+class ScanOutputWriter:
+    '''
+    Utility for writing scan result payloads to file.
+    Supports YAML and JSON formats with auto-detection from file extension.
+    '''
+
+    # * method: detect_format (static)
+    @staticmethod
+    def detect_format(output_path: str, output_format: str = 'yaml') -> str:
+        '''
+        Resolve the output format. If ``output_format`` is ``'auto'``,
+        detect from the file extension; otherwise return ``output_format``
+        unchanged.
+
+        :param output_path: The target file path.
+        :type output_path: str
+        :param output_format: Explicit format or ``'auto'`` for detection.
+        :type output_format: str
+        :return: Resolved format string (``'yaml'`` or ``'json'``).
+        :rtype: str
+        '''
+
+        # Auto-detect format from file extension.
+        if output_format == 'auto':
+            ext = os.path.splitext(output_path)[1].lower()
+            if ext == '.json':
+                return 'json'
+            return 'yaml'
+
+        # Return the explicit format.
+        return output_format
+
+    # * method: write (static)
+    @staticmethod
+    def write(result: Dict[str, Any], output_path: str, output_format: str = 'yaml') -> None:
+        '''
+        Write a result payload to a file in the specified format.
+
+        :param result: The result payload to write.
+        :type result: Dict[str, Any]
+        :param output_path: The file path to write to.
+        :type output_path: str
+        :param output_format: The output format (``'yaml'``, ``'json'``, or ``'auto'``).
+        :type output_format: str
+        '''
+
+        # Resolve the format.
+        fmt = ScanOutputWriter.detect_format(output_path, output_format)
+
+        # Write the output file.
+        with open(output_path, 'w', encoding='utf-8') as f:
+            if fmt == 'json':
+                json.dump(result, f, indent=2, default=str)
+            else:
+                yaml.dump(result, f, default_flow_style=False, sort_keys=False)
+
+    # * method: parse_extract_names (static)
+    @staticmethod
+    def parse_extract_names(extract: str) -> Optional[List[str]]:
+        '''
+        Parse a comma-separated extract filter string into a list of names
+        suitable for inclusion in the output payload.
+
+        :param extract: Comma-separated artifact names, or None.
+        :type extract: str
+        :return: A list of stripped names, or None if extract is falsy.
+        :rtype: Optional[List[str]]
+        '''
+
+        # Return None if no filter provided.
+        if not extract:
+            return None
+
+        # Split, strip, and return as a list.
+        return [name.strip() for name in extract.split(',')]

--- a/src/utils/tests/test_output.py
+++ b/src/utils/tests/test_output.py
@@ -1,0 +1,191 @@
+"""Scan Output Writer Utility Tests"""
+
+# *** imports
+
+# ** core
+import os
+import json
+
+# ** infra
+import pytest
+import yaml
+
+# ** app
+from ..output import ScanOutputWriter
+
+# *** tests — detect_format
+
+# ** test: detect_format_auto_json
+def test_detect_format_auto_json() -> None:
+    '''
+    Test auto-detection resolves .json extension to json format.
+    '''
+
+    # Detect format for a .json file path.
+    result = ScanOutputWriter.detect_format('output.json', 'auto')
+
+    # Assert json format detected.
+    assert result == 'json'
+
+
+# ** test: detect_format_auto_yaml
+def test_detect_format_auto_yaml() -> None:
+    '''
+    Test auto-detection resolves .yaml extension to yaml format.
+    '''
+
+    # Detect format for a .yaml file path.
+    result = ScanOutputWriter.detect_format('output.yaml', 'auto')
+
+    # Assert yaml format detected.
+    assert result == 'yaml'
+
+
+# ** test: detect_format_auto_unknown_defaults_yaml
+def test_detect_format_auto_unknown_defaults_yaml() -> None:
+    '''
+    Test auto-detection defaults to yaml for unknown extensions.
+    '''
+
+    # Detect format for a .txt file path.
+    result = ScanOutputWriter.detect_format('output.txt', 'auto')
+
+    # Assert yaml format as default.
+    assert result == 'yaml'
+
+
+# ** test: detect_format_explicit
+def test_detect_format_explicit() -> None:
+    '''
+    Test that explicit format is returned regardless of file extension.
+    '''
+
+    # Detect format with explicit json, even for a .yaml path.
+    result = ScanOutputWriter.detect_format('output.yaml', 'json')
+
+    # Assert the explicit format is honored.
+    assert result == 'json'
+
+# *** tests — write
+
+# ** test: write_yaml
+def test_write_yaml(tmp_path) -> None:
+    '''
+    Test writing a result payload as YAML.
+
+    :param tmp_path: Pytest temporary directory fixture.
+    :type tmp_path: pathlib.Path
+    '''
+
+    # Build a sample payload.
+    payload = {'event_type': 'TokensScanned', 'token_count': 5}
+
+    # Write as YAML.
+    output_path = str(tmp_path / 'result.yaml')
+    ScanOutputWriter.write(payload, output_path, 'yaml')
+
+    # Assert file was created and contains valid YAML.
+    assert os.path.isfile(output_path)
+    with open(output_path) as f:
+        loaded = yaml.safe_load(f)
+    assert loaded['event_type'] == 'TokensScanned'
+    assert loaded['token_count'] == 5
+
+
+# ** test: write_json
+def test_write_json(tmp_path) -> None:
+    '''
+    Test writing a result payload as JSON.
+
+    :param tmp_path: Pytest temporary directory fixture.
+    :type tmp_path: pathlib.Path
+    '''
+
+    # Build a sample payload.
+    payload = {'event_type': 'TokensScanned', 'token_count': 5}
+
+    # Write as JSON.
+    output_path = str(tmp_path / 'result.json')
+    ScanOutputWriter.write(payload, output_path, 'json')
+
+    # Assert file was created and contains valid JSON.
+    assert os.path.isfile(output_path)
+    with open(output_path) as f:
+        loaded = json.load(f)
+    assert loaded['event_type'] == 'TokensScanned'
+    assert loaded['token_count'] == 5
+
+
+# ** test: write_auto_json
+def test_write_auto_json(tmp_path) -> None:
+    '''
+    Test that auto format writes JSON when the path ends in .json.
+
+    :param tmp_path: Pytest temporary directory fixture.
+    :type tmp_path: pathlib.Path
+    '''
+
+    # Build a sample payload.
+    payload = {'event_type': 'TokensScanned'}
+
+    # Write with auto format to a .json path.
+    output_path = str(tmp_path / 'result.json')
+    ScanOutputWriter.write(payload, output_path, 'auto')
+
+    # Assert valid JSON was written.
+    with open(output_path) as f:
+        loaded = json.load(f)
+    assert loaded['event_type'] == 'TokensScanned'
+
+# *** tests — parse_extract_names
+
+# ** test: parse_extract_names_none
+def test_parse_extract_names_none() -> None:
+    '''
+    Test that None input returns None.
+    '''
+
+    # Parse None.
+    result = ScanOutputWriter.parse_extract_names(None)
+
+    # Assert None is returned.
+    assert result is None
+
+
+# ** test: parse_extract_names_empty
+def test_parse_extract_names_empty() -> None:
+    '''
+    Test that empty string returns None.
+    '''
+
+    # Parse empty string.
+    result = ScanOutputWriter.parse_extract_names('')
+
+    # Assert None is returned.
+    assert result is None
+
+
+# ** test: parse_extract_names_single
+def test_parse_extract_names_single() -> None:
+    '''
+    Test parsing a single artifact name returns a one-element list.
+    '''
+
+    # Parse a single name.
+    result = ScanOutputWriter.parse_extract_names('add_item')
+
+    # Assert list with one element.
+    assert result == ['add_item']
+
+
+# ** test: parse_extract_names_multiple
+def test_parse_extract_names_multiple() -> None:
+    '''
+    Test parsing comma-separated names with whitespace preserves order.
+    '''
+
+    # Parse multiple names.
+    result = ScanOutputWriter.parse_extract_names('add_item, remove_item , get_item')
+
+    # Assert all names stripped and present in order.
+    assert result == ['add_item', 'remove_item', 'get_item']


### PR DESCRIPTION
## Summary

Implements TRD #22 — introduces `ScanOutputWriter`, a static utility class that writes scan result payloads to file in YAML or JSON. Encapsulates the file I/O logic currently inline in `EmitScanResult.execute()` (the `_write_output` instance method), making it independently testable and reusable.

## Changes

### `src/utils/output.py` (new)
- `ScanOutputWriter` utility class under `# *** utils` / `# ** util: scan_output_writer`
- **`detect_format(output_path, output_format)`** — resolves `'auto'` to `'json'` or `'yaml'` by file extension; passes explicit formats through unchanged
- **`write(result, output_path, output_format)`** — serializes payload to file; JSON uses `indent=2` + `default=str`, YAML uses `default_flow_style=False` + `sort_keys=False`
- **`parse_extract_names(extract)`** — converts comma-separated string to ordered `List[str]`; returns `None` for falsy input

### `src/utils/__init__.py`
- Added `from .output import ScanOutputWriter` to exports

### `src/utils/tests/test_output.py` (new)
- 11 tests: detect_format (4), write (3), parse_extract_names (4)
- Write tests use `tmp_path` fixture with YAML/JSON round-trip assertions

## Acceptance Criteria
- [x] `ScanOutputWriter` exported from `src/utils/__init__.py`
- [x] All 3 static methods implemented
- [x] 11 tests passing

Closes #22