### PR TITLE
Scanner Domain Events Refactor

### DIFF
--- a/src/events/scan.py
+++ b/src/events/scan.py
@@ -4,18 +4,14 @@
 
 # ** core
 import os
-import re
-import json
 from collections import Counter
 from datetime import datetime, timezone
 from typing import List, Dict, Any
 
-# ** infra
-import yaml
-
 # ** app
 from .settings import DomainEvent, a
 from ..interfaces import LexerService
+from ..utils import ArtifactBlockParser, ScanOutputWriter, IndentInjector
 
 # *** events
 
@@ -61,77 +57,17 @@ class ExtractText(DomainEvent):
         with open(source_file, 'r', encoding='utf-8') as f:
             lines = f.readlines()
 
-        # Build patterns for the given group type and imports section.
-        section_pattern = re.compile(
-            rf'^\s*#\s*\*\*\s+{re.escape(group_type)}:\s+(\S+)'
-        )
-        imports_start_pattern = re.compile(r'^\s*#\s*\*{3}\s+imports\s*$')
-        top_level_pattern = re.compile(r'^\s*#\s*\*{3}\s+\S+')
-
         # Parse optional extract filter into a set.
-        extract_ids = None
-        if extract:
-            extract_ids = set(name.strip() for name in extract.split(','))
+        extract_ids = ArtifactBlockParser.parse_extract_filter(extract)
 
-        # Locate the imports section (from # *** imports to next # *** section).
-        imports_block = None
-        imports_start = None
+        # Extract the imports block.
+        imports_block = ArtifactBlockParser.extract_imports_block(lines)
 
-        for i, line in enumerate(lines):
-            if imports_start is None:
-                if imports_start_pattern.match(line):
-                    imports_start = i
-            elif top_level_pattern.match(line):
-                imports_block = {
-                    'name': '__imports__',
-                    'line_start': imports_start,
-                    'line_end': i,
-                    'text': ''.join(lines[imports_start:i]),
-                    'length_chars': 0,
-                }
-                imports_block['length_chars'] = len(imports_block['text'])
-                break
-
-        # Walk lines to find matching artifact blocks.
-        blocks = []
-        current_block = None
-
-        for i, line in enumerate(lines):
-            match = section_pattern.match(line)
-
-            if match:
-
-                # Close the previous block if open.
-                if current_block is not None:
-                    current_block['line_end'] = i
-                    current_block['text'] = ''.join(
-                        lines[current_block['line_start']:i]
-                    )
-                    current_block['length_chars'] = len(current_block['text'])
-                    blocks.append(current_block)
-
-                # Start a new block.
-                name = match.group(1)
-                current_block = {
-                    'name': name,
-                    'line_start': i,
-                    'line_end': None,
-                    'text': None,
-                    'length_chars': 0,
-                }
-
-        # Close the last block.
-        if current_block is not None:
-            current_block['line_end'] = len(lines)
-            current_block['text'] = ''.join(
-                lines[current_block['line_start']:]
-            )
-            current_block['length_chars'] = len(current_block['text'])
-            blocks.append(current_block)
+        # Extract artifact blocks for the given group type.
+        blocks = ArtifactBlockParser.extract_artifact_blocks(lines, group_type)
 
         # Apply extract filter if specified (imports are always included).
-        if extract_ids:
-            blocks = [b for b in blocks if b['name'] in extract_ids]
+        blocks = ArtifactBlockParser.filter_blocks(blocks, extract_ids)
 
         # Prepend the imports block if found.
         if imports_block:
@@ -239,19 +175,18 @@ class PerformLexicalAnalysis(DomainEvent):
             block_tokens = self.lexer_service.tokenize(block['text'])
             all_tokens.extend(block_tokens)
 
-        # Count token types for metrics computation.
+        # Inject INDENT/DEDENT tokens within method and init bodies.
+        all_tokens = IndentInjector.inject(all_tokens)
+
+        # Count token types for metrics computation (post-injection).
         type_counts = Counter(t['type'] for t in all_tokens)
 
         # Compute domain metrics from token type counts.
         metrics = {
             'commands_detected': type_counts.get('CLASS', 0),
-            'execute_methods_found': type_counts.get('EXECUTE', 0),
-            'verify_calls': type_counts.get('VERIFY', 0),
-            'parameters_required_decorators': type_counts.get('PARAMETERS_REQUIRED', 0),
-            'service_calls': type_counts.get('SERVICE_CALL', 0),
-            'factory_calls': type_counts.get('FACTORY_CALL', 0),
-            'constants_referenced': type_counts.get('CONST_REF', 0),
             'docstrings_found': type_counts.get('DOCSTRING', 0),
+            'indent_count': type_counts.get('INDENT', 0),
+            'dedent_count': type_counts.get('DEDENT', 0),
             'top_token_types': dict(type_counts.most_common(10)),
         }
 
@@ -323,10 +258,9 @@ class EmitScanResult(DomainEvent):
         }
 
         # Include extracted artifact names if -x was used.
-        if extract:
-            result['extracted_artifacts'] = [
-                name.strip() for name in extract.split(',')
-            ]
+        extracted_names = ScanOutputWriter.parse_extract_names(extract)
+        if extracted_names:
+            result['extracted_artifacts'] = extracted_names
 
         # Include metrics if requested.
         if with_metrics or summary_only:
@@ -338,35 +272,7 @@ class EmitScanResult(DomainEvent):
 
         # Write to file if output path specified.
         if output:
-            self._write_output(result, output, output_format)
+            ScanOutputWriter.write(result, output, output_format)
 
         # Return the result payload.
         return result
-
-    # * method: _write_output
-    def _write_output(self, result: Dict[str, Any], output_path: str, output_format: str) -> None:
-        '''
-        Write the result payload to a file.
-
-        :param result: The result payload to write.
-        :type result: Dict[str, Any]
-        :param output_path: The file path to write to.
-        :type output_path: str
-        :param output_format: The output format (yaml, json, or auto).
-        :type output_format: str
-        '''
-
-        # Auto-detect format from file extension.
-        if output_format == 'auto':
-            ext = os.path.splitext(output_path)[1].lower()
-            if ext == '.json':
-                output_format = 'json'
-            else:
-                output_format = 'yaml'
-
-        # Write the output file.
-        with open(output_path, 'w', encoding='utf-8') as f:
-            if output_format == 'json':
-                json.dump(result, f, indent=2, default=str)
-            else:
-                yaml.dump(result, f, default_flow_style=False, sort_keys=False)

--- a/src/events/tests/test_scan.py
+++ b/src/events/tests/test_scan.py
@@ -289,7 +289,7 @@ def test_perform_lexical_analysis_success(
     mock_lexer_service.tokenize.return_value = [
         {'type': 'CLASS', 'value': 'class', 'line': 1, 'column': 0},
         {'type': 'IDENTIFIER', 'value': 'SampleEvent', 'line': 1, 'column': 6},
-        {'type': 'EXECUTE', 'value': 'execute', 'line': 3, 'column': 8},
+        {'type': 'IDENTIFIER', 'value': 'execute', 'line': 3, 'column': 8},
     ]
 
     # Execute via DomainEvent.handle with injected dependency.
@@ -305,7 +305,8 @@ def test_perform_lexical_analysis_success(
     assert 'metrics' in result
     assert result['token_count'] == 3
     assert result['metrics']['commands_detected'] == 1
-    assert result['metrics']['execute_methods_found'] == 1
+    assert result['metrics']['indent_count'] == 0
+    assert result['metrics']['dedent_count'] == 0
 
     # Verify the lexer service was called.
     mock_lexer_service.tokenize.assert_called_once_with(sample_text_blocks[0]['text'])


### PR DESCRIPTION
## Summary

Implements TRD #24 — refactors the three scan events that had inline infrastructure logic to delegate to the utility classes introduced in TRDs #21–#23. Net result: 115 lines removed, 22 added. `LexerInitialized` is unchanged.

## Changes

### `src/events/scan.py`

**Imports**
- Removed: `re`, `json`, `yaml` (no longer needed directly)
- Added: `ArtifactBlockParser`, `ScanOutputWriter`, `IndentInjector` from `..utils`

**`ExtractText.execute()`**
- Replaced ~50 lines of inline regex patterns and block-walking loops with 4 delegations to `ArtifactBlockParser`:
  - `parse_extract_filter(extract)`
  - `extract_imports_block(lines)`
  - `extract_artifact_blocks(lines, group_type)`
  - `filter_blocks(blocks, extract_ids)`

**`PerformLexicalAnalysis.execute()`**
- Added `IndentInjector.inject(all_tokens)` call post-tokenization
- Rewrote metrics dict: replaced stale token references (`EXECUTE`, `VERIFY`, `PARAMETERS_REQUIRED`, `SERVICE_CALL`, `FACTORY_CALL`, `CONST_REF`) with `indent_count` and `dedent_count`

**`EmitScanResult.execute()`**
- Replaced inline `extracted_artifacts` list comprehension with `ScanOutputWriter.parse_extract_names(extract)`
- Replaced `self._write_output(...)` call with `ScanOutputWriter.write(result, output, output_format)`
- Removed `_write_output` instance method entirely

### `src/events/tests/test_scan.py`
- `test_perform_lexical_analysis_success`: changed `EXECUTE` token to `IDENTIFIER`; replaced `execute_methods_found == 1` assertion with `indent_count == 0` and `dedent_count == 0`

## Acceptance Criteria
- [x] `re`, `json`, `yaml` removed from `scan.py` imports
- [x] `ExtractText` delegates fully to `ArtifactBlockParser`
- [x] `PerformLexicalAnalysis` calls `IndentInjector.inject()` and uses updated metrics
- [x] `EmitScanResult` uses `ScanOutputWriter` for both output writing and extract name parsing; `_write_output` removed
- [x] All 17 `test_scan.py` tests passing

Closes #24