### PR TITLE
v0.2.0 Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,4 +207,3 @@ marimo/_lsp/
 __marimo__/
 
 # Project-specific
-samples/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,20 @@
 # Tiferet Command Parser — Educational Scanner
 
 **Repository:** tiferet-command-parser-edu
-**Version:** 0.1.0
-**Branch:** master
+**Version:** 0.2.0
+**Branch:** v0.2-release
 **Framework:** Tiferet (DDD, Domain Events)
 **Purpose:** Educational compiler front-end for ECE 506 (Compiler Design) — performs lexical scanning on Python source files written in the Tiferet framework's Domain Event pattern.
 
 ## Architecture
 
-This project is a Tiferet application. It uses Domain Events as the primary operational units, wired via YAML configuration (`config.yml`), and executed through the Tiferet CLI context. The scanner reads Tiferet-patterned Python source files, extracts artifact blocks (including imports), tokenizes them using a PLY-based lexer, computes domain metrics, and emits structured output (YAML/JSON).
+This project is a Tiferet application. It uses Domain Events as the primary operational units, wired via YAML configuration (`config.yml`), and executed through the Tiferet CLI context. The scanner reads Tiferet-patterned Python source files, extracts artifact blocks (including imports), tokenizes them using a PLY-based lexer, injects synthetic layout tokens, computes domain metrics, and emits structured output (YAML/JSON).
 
 ### Pipeline (Feature: `scan.event`)
 
 1. **ExtractText** — Reads source file, extracts `# *** imports` block and `# ** event:` artifact blocks. Supports `-x` filtering; imports are always included.
 2. **LexerInitialized** — Validates that extracted text blocks are non-empty and ready for tokenization.
-3. **PerformLexicalAnalysis** — Tokenizes blocks via `LexerService`, computes domain metrics (class count, verify calls, service calls, etc.).
+3. **PerformLexicalAnalysis** — Tokenizes blocks via `LexerService`, injects `INDENT`/`DEDENT` tokens via `IndentInjector`, and computes domain metrics.
 4. **EmitScanResult** — Assembles the final payload with optional metrics, summary-only mode, extracted artifact names, and file output.
 
 ## Project Structure
@@ -23,15 +23,27 @@ This project is a Tiferet application. It uses Domain Events as the primary oper
 compiler.py              — Entry point: loads Tiferet CLI app from config.yml
 config.yml               — Tiferet app configuration (attrs, features, errors, cli, interfaces)
 pyproject.toml           — Project metadata, dependencies (tiferet, ply, pyyaml)
+docs/
+  guides/
+    lexical_spec.md      — Formal lexical specification for all 53 token types
 samples/
-  error_events.py        — Sample input: Tiferet error event source file
+  empty_events.py                    — Empty placeholder events module (success case)
+  add_error_event.py                 — Single AddError event with service injection (success case)
+  error_events.py                    — Multi-event module: AddError, GetError, ListErrors, RenameError (success case)
+  obsolete_rename_error_event.py     — RenameError with OBSOLETE-annotated method (success case)
+  todo_get_error_event.py            — GetError with TODO-annotated method (success case)
+  invalid_identifier_names_event.py  — Digit-prefixed class and member names (failure case)
+  invalid_annotation_event.py        — Malformed OBSOLETE/TODO annotations (failure case)
 
 src/
-  __init__.py            — Package exports and version (0.1.0)
+  __init__.py            — Package exports and version (0.2.0)
+  assets/
+    __init__.py          — Assets package exports
+    lexer.py             — Token constants (53 types), rule handlers (functions/regexes), RULES mapping dict
   domain/
     __init__.py          — Reserved for future domain objects
   events/
-    settings.py          — Re-exports DomainEvent, TiferetError, a from tiferet.events
+    settings.py          — Re-exports DomainEvent, TiferetError; imports local assets as `a`
     scan.py              — Scanner domain events: ExtractText, LexerInitialized, PerformLexicalAnalysis, EmitScanResult
     __init__.py          — Events package exports
     tests/
@@ -40,30 +52,55 @@ src/
     lexer.py             — LexerService abstract interface (extends tiferet Service)
     __init__.py          — Interfaces package exports
   utils/
-    lexer.py             — TiferetLexer: PLY-based lexer implementing LexerService with 35 token types
+    lexer.py             — TiferetLexer: generic PLY host that loads tokens and rules dynamically from assets
+    parser.py            — ArtifactBlockParser: artifact block extraction, imports parsing, extract filtering
+    output.py            — ScanOutputWriter: file output with YAML/JSON format auto-detection
+    indent.py            — IndentInjector: post-tokenization INDENT/DEDENT injection for method bodies
     __init__.py          — Utils package exports
     tests/
-      test_lexer.py      — 37 tests for all lexer token rules
+      test_lexer.py      — 43 tests for all lexer token rules
+      test_parser.py     — 13 tests for artifact block parser utility
+      test_output.py     — 11 tests for scan output writer utility
+      test_indent.py     — 12 tests for IndentInjector
 ```
 
 ## Key Files
 
 ### `src/events/scan.py`
-All scanner domain events. Each event follows the Tiferet pattern: `@DomainEvent.parameters_required` for validation, `self.verify()` for domain rules, service injection via constructor.
+All scanner domain events. Each event follows the Tiferet pattern: `@DomainEvent.parameters_required` for validation, `self.verify()` for domain rules, service injection via constructor. Parsing and output concerns are delegated to utility classes.
 
-- **ExtractText** — Parses source files for `# *** imports` and `# ** <group_type>:` blocks. The imports block (`__imports__`) is always included, even with `-x` extract filtering.
+- **ExtractText** — Reads source file, delegates artifact extraction to `ArtifactBlockParser`. The imports block (`__imports__`) is always included, even with `-x` extract filtering.
 - **LexerInitialized** — Validates block content is non-empty.
-- **PerformLexicalAnalysis** — Injects `LexerService`, tokenizes blocks, computes metrics via `Counter`.
-- **EmitScanResult** — Builds output payload. Includes `extracted_artifacts` list when `-x` is used. Supports `--summary-only` and `--with-metrics` flags.
+- **PerformLexicalAnalysis** — Injects `LexerService`, tokenizes blocks, runs `IndentInjector.inject()` post-tokenization, computes metrics via `Counter`.
+- **EmitScanResult** — Builds output payload. Delegates file writing to `ScanOutputWriter`. Supports `--summary-only` and `--with-metrics` flags.
+
+### `src/utils/indent.py`
+Post-tokenization utility (`IndentInjector`) with a single static method:
+- **`inject(tokens)`** — Injects `INDENT`/`DEDENT` tokens at method-body indentation boundaries. Enters body mode on `ARTIFACT_MEMBER` matching `# * method:` or `# * init`, tracks paren depth to skip multi-line signatures, manages a column stack to handle nested indentation.
+
+### `src/utils/parser.py`
+Artifact block parser (`ArtifactBlockParser`) with static methods:
+- **`parse_extract_filter`** — Converts comma-separated extract string to a set of names.
+- **`extract_imports_block`** — Locates and extracts the `# *** imports` section.
+- **`extract_artifact_blocks`** — Walks source lines to extract all blocks matching a group type.
+- **`filter_blocks`** — Applies an optional name filter to a list of blocks.
+
+### `src/utils/output.py`
+Scan output writer (`ScanOutputWriter`) with static methods:
+- **`detect_format`** — Resolves output format from explicit value or file extension auto-detection.
+- **`write`** — Writes a result payload to file as YAML or JSON.
+- **`parse_extract_names`** — Converts comma-separated extract string to a list for payload inclusion.
 
 ### `src/utils/lexer.py`
-PLY-based lexer (`TiferetLexer`) with token types organized by category:
+Generic PLY lexer host (`TiferetLexer`) with 53 token types organized by category:
 
-- **Artifact comments:** `ARTIFACT_IMPORTS_START`, `ARTIFACT_IMPORT_GROUP`, `ARTIFACT_START`, `ARTIFACT_SECTION`, `ARTIFACT_MEMBER`
-- **Domain idioms:** `PARAMETERS_REQUIRED`, `VERIFY`, `SERVICE_CALL`, `FACTORY_CALL`, `CONST_REF`
-- **Structural:** `CLASS`, `DEF`, `INIT`, `EXECUTE`, `RETURN`, `SELF`
-- **Generic:** `PYTHON_KEYWORD`, `IDENTIFIER`, `STRING_LITERAL`, `NUMBER_LITERAL`, `DOCSTRING`, `LINE_COMMENT`
+- **Artifact comments:** `ARTIFACT_IMPORTS_START`, `ARTIFACT_IMPORT_GROUP`, `ARTIFACT_START`, `ARTIFACT_SECTION`, `ARTIFACT_MEMBER`, `OBSOLETE`, `TODO`
+- **Documentation:** `DOCSTRING`, `LINE_COMMENT`
+- **Structural:** `CLASS`, `DEF`, `INIT`, `RETURN`, `SELF`
+- **Generic:** `PYTHON_KEYWORD`, `IDENTIFIER`, `STRING_LITERAL`, `NUMBER_LITERAL`
+- **Operators:** `DOUBLESTAR`, `PLUS`, `MINUS`, `STAR`, `SLASH`, `DOUBLESLASH`, `PERCENT`, `PIPE`, `AMPERSAND`, `TILDE`, `CARET`, `LSHIFT`, `RSHIFT`, `EQEQ`, `NOTEQ`, `LTEQ`, `GTEQ`, `LT`, `GT`, `AT`
 - **Punctuation/Layout:** `LPAREN`, `RPAREN`, `LBRACK`, `RBRACK`, `LBRACE`, `RBRACE`, `COMMA`, `COLON`, `ARROW`, `DOT`, `EQUALS`, `NEWLINE`, `UNKNOWN`
+- **Indentation (injected):** `INDENT`, `DEDENT`
 
 ### `src/interfaces/lexer.py`
 Abstract `LexerService(Service)` with single method `tokenize(text) -> List[Dict]`.
@@ -95,10 +132,10 @@ python compiler.py scan event <source_file> -o output.yaml -x add_error,get_erro
 ## Testing
 
 ```bash
-python -m pytest src/ -v    # 54 tests (37 lexer + 17 events)
+python -m pytest src/ -v    # 96 tests (43 lexer + 13 parser + 11 output + 12 indent + 17 events)
 ```
 
-Tests use `DomainEvent.handle` for event invocation and mock `LexerService` for isolation.
+Tests use `DomainEvent.handle` for event invocation and mock `LexerService` for isolation. Utility tests validate parsing and output logic independently of domain events.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ python compiler.py scan event <source_file>
 
 ```bash
 # Full scan with YAML output
-python compiler.py scan event samples/error_events.py -o results.yaml
+python compiler.py scan event samples/add_error_event.py -o results.yaml
 
 # JSON output
-python compiler.py scan event samples/error_events.py -o results.json --format json
+python compiler.py scan event samples/add_error_event.py -o results.json --format json
 
 # Summary with metrics only (no token list)
 python compiler.py scan event samples/error_events.py --summary-only true --with-metrics true
@@ -74,17 +74,38 @@ python compiler.py scan event samples/error_events.py -x add_error,get_error
 
 #### Token Categories
 
-The scanner recognizes the following token families (see [LEXICAL_SPEC.md](./LEXICAL_SPEC.md) for the complete formal specification):
+The scanner recognizes the following token families (see [lexical_spec.md](./docs/guides/lexical_spec.md) for the complete formal specification):
 
-- **Artifact Comments** — `ARTIFACT_START`, `ARTIFACT_SECTION`, `ARTIFACT_MEMBER`, `ARTIFACT_IMPORTS_START`, `ARTIFACT_IMPORT_GROUP`
+- **Artifact Comments** — `ARTIFACT_IMPORTS_START`, `ARTIFACT_IMPORT_GROUP`, `ARTIFACT_START`, `ARTIFACT_SECTION`, `ARTIFACT_MEMBER`, `OBSOLETE`, `TODO`
 - **Documentation** — `DOCSTRING`, `LINE_COMMENT`
-- **Structural Keywords** — `CLASS`, `DEF`, `EXECUTE`, `INIT`, `RETURN`, `SELF`
-- **Domain Idioms** — `PARAMETERS_REQUIRED`, `VERIFY`, `SERVICE_CALL`, `FACTORY_CALL`, `CONST_REF`
+- **Structural Keywords** — `CLASS`, `DEF`, `INIT`, `RETURN`, `SELF`
 - **Generic Python** — `PYTHON_KEYWORD`, `IDENTIFIER`, `STRING_LITERAL`, `NUMBER_LITERAL`
+- **Operators** — `DOUBLESTAR`, `PLUS`, `MINUS`, `STAR`, `SLASH`, `DOUBLESLASH`, `PERCENT`, `PIPE`, `AMPERSAND`, `TILDE`, `CARET`, `LSHIFT`, `RSHIFT`, `EQEQ`, `NOTEQ`, `LTEQ`, `GTEQ`, `LT`, `GT`, `AT`
 - **Punctuation** — `LPAREN`, `RPAREN`, `LBRACK`, `RBRACK`, `LBRACE`, `RBRACE`, `COMMA`, `COLON`, `ARROW`, `DOT`, `EQUALS`
-- **Layout** — `NEWLINE`, `UNKNOWN`
+- **Layout & Indentation** — `NEWLINE`, `UNKNOWN`, `INDENT`, `DEDENT`
 
 Unrecognized characters are emitted as `UNKNOWN` tokens for error reporting.
+
+### Sample Files
+
+The `samples/` directory contains 7 Tiferet Domain Event source files for testing the scanner. Five are well-formed success cases; two are intentional failure cases that demonstrate specific token behaviors.
+
+**Success cases:**
+
+| File | Description |
+|------|-------------|
+| `empty_events.py` | Minimal placeholder events module — baseline success case |
+| `add_error_event.py` | Single `AddError` event — error creation with service injection and aggregate factory |
+| `error_events.py` | Multi-event module — `AddError`, `GetError`, `ListErrors`, `RenameError`, and more |
+| `obsolete_rename_error_event.py` | `RenameError` event with `OBSOLETE`-annotated method — tests `OBSOLETE` token recognition |
+| `todo_get_error_event.py` | `GetError` event with `TODO`-annotated method — tests `TODO` token recognition |
+
+**Failure cases:**
+
+| File | Description |
+|------|-------------|
+| `invalid_identifier_names_event.py` | Digit-prefixed class name and member names — lexer emits `UNKNOWN` tokens |
+| `invalid_annotation_event.py` | `OBSOLETE`/`TODO` comments without required `colon: description` — emitted as `LINE_COMMENT` |
 
 ### Running Tests
 
@@ -94,14 +115,23 @@ The test suite validates every token type, non-matching/unknown tokens, and the 
 # Run all tests
 python -m pytest src/ -v
 
-# Run only lexer tests (37 tests)
+# Run only lexer tests (43 tests)
 python -m pytest src/utils/tests/test_lexer.py -v
+
+# Run only parser utility tests (13 tests)
+python -m pytest src/utils/tests/test_parser.py -v
+
+# Run only output utility tests (11 tests)
+python -m pytest src/utils/tests/test_output.py -v
+
+# Run only indent injector tests (12 tests)
+python -m pytest src/utils/tests/test_indent.py -v
 
 # Run only event tests (17 tests)
 python -m pytest src/events/tests/test_scan.py -v
 ```
 
-**Total: 54 tests** (37 lexer + 17 events)
+**Total: 96 tests** (43 lexer + 13 parser + 11 output + 12 indent + 17 events)
 
 ### Project Structure
 
@@ -109,15 +139,27 @@ python -m pytest src/events/tests/test_scan.py -v
 compiler.py              — Entry point: loads Tiferet CLI app from config.yml
 config.yml               — Tiferet app configuration (attrs, features, errors, cli, interfaces)
 pyproject.toml           — Project metadata, dependencies (tiferet, ply, pyyaml)
+docs/
+  guides/
+    lexical_spec.md      — Formal lexical specification for all 53 token types
 samples/
-  error_events.py        — Sample input: Tiferet error event source file
+  empty_events.py                    — Empty placeholder events module (success case)
+  add_error_event.py                 — Single AddError event with service injection (success case)
+  error_events.py                    — Multi-event module: AddError, GetError, ListErrors, RenameError (success case)
+  obsolete_rename_error_event.py     — RenameError with OBSOLETE-annotated method (success case)
+  todo_get_error_event.py            — GetError with TODO-annotated method (success case)
+  invalid_identifier_names_event.py  — Digit-prefixed class and member names (failure case)
+  invalid_annotation_event.py        — Malformed OBSOLETE/TODO annotations (failure case)
 
 src/
-  __init__.py            — Package exports and version (0.1.0)
+  __init__.py            — Package exports and version (0.2.0)
+  assets/
+    __init__.py          — Assets package exports
+    lexer.py             — Token constants (53 types), rule handlers, RULES mapping dict
   domain/
     __init__.py          — Reserved for future domain objects
   events/
-    settings.py          — Re-exports DomainEvent, TiferetError, a from tiferet.events
+    settings.py          — Re-exports DomainEvent, TiferetError; imports local assets as `a`
     scan.py              — Scanner domain events: ExtractText, LexerInitialized, PerformLexicalAnalysis, EmitScanResult
     __init__.py          — Events package exports
     tests/
@@ -126,22 +168,28 @@ src/
     lexer.py             — LexerService abstract interface (extends tiferet Service)
     __init__.py          — Interfaces package exports
   utils/
-    lexer.py             — TiferetLexer: PLY-based lexer implementing LexerService with 35 token types
+    lexer.py             — TiferetLexer: generic PLY host that loads tokens and rules dynamically from assets
+    parser.py            — ArtifactBlockParser: artifact block extraction, imports parsing, extract filtering
+    output.py            — ScanOutputWriter: file output with YAML/JSON format auto-detection
+    indent.py            — IndentInjector: post-tokenization INDENT/DEDENT injection for method bodies
     __init__.py          — Utils package exports
     tests/
-      test_lexer.py      — 37 tests for all lexer token rules
+      test_lexer.py      — 43 tests for all lexer token rules
+      test_parser.py     — 13 tests for artifact block parser utility
+      test_output.py     — 11 tests for scan output writer utility
+      test_indent.py     — 12 tests for IndentInjector
 ```
 
 ### Project Documentation
 - **[PROJECT_SUMMARY.md](./PROJECT_SUMMARY.md)** — ECE 506 course context and educational goals
 - **[PROJECT_PROPOSAL.md](./PROJECT_PROPOSAL.md)** — Completed ECE 506 initial project definition template
-- **[LEXICAL_SPEC.md](./LEXICAL_SPEC.md)** — Formal lexical specification for all token types
+- **[lexical_spec.md](./docs/guides/lexical_spec.md)** — Formal lexical specification for all token types
 - **[AGENTS.md](./AGENTS.md)** — AI agent codebase index
 
 ### Development Status
 
-- **Current branch**: `master`
-- **Version**: 0.1.0
+- **Current branch**: `v0.2-release`
+- **Version**: 0.2.0
 - **Focus**: Lexical scanner for the Tiferet Domain Event pattern
 - **License**: MIT (educational reuse encouraged)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.backends._legacy:_Backend"
 
 [project]
 name = "tiferet-command-parser-edu"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Educational parser and static analysis tool for the Tiferet Command pattern"
 readme = "README.md"
 license = {text = "MIT"}
@@ -19,6 +19,9 @@ dependencies = [
 dev = [
     "pytest>=7.0",
 ]
+
+[tool.setuptools.dynamic]
+version = {attr = "src.__version__"}
 
 [tool.pytest.ini_options]
 testpaths = ["src"]

--- a/samples/add_error_event.py
+++ b/samples/add_error_event.py
@@ -1,0 +1,79 @@
+"""Tiferet Add Error Event Sample"""
+
+# *** imports
+
+# ** core
+from typing import (
+    List,
+    Dict,
+    Any
+)
+
+# ** app
+from .settings import DomainEvent, a
+from ..domain import Error
+from ..interfaces import ErrorService
+from ..mappers import Aggregate, ErrorAggregate
+
+# *** events
+
+# ** event: add_error
+class AddError(DomainEvent):
+    """
+    Command to add a new Error domain object to the repository.
+    """
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        """
+        Initialize the AddError command.
+
+        :param error_repo: The error service to use.
+        :type error_repo: ErrorService
+        """
+        self.error_service = error_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'name', 'message'])
+    def execute(self,id: str, name: str, message: str, lang: str = 'en_US', additional_messages: List[Dict[str, Any]] = []) -> None:
+        """
+        Add a new Error to the app.
+
+        :param id: The unique identifier of the error.
+        :type id: str
+        :param name: The name of the error.
+        :type name: str
+        :param message: The primary error message text.
+        :type message: str
+        :param lang: The language of the primary error message (default is 'en_US').
+        :type lang: str
+        :param additional_messages: Additional error messages in different languages.
+        :type additional_messages: List[Dict[str, Any]]
+        """
+
+        # Check if an error with the same ID already exists.
+        exists = self.error_service.exists(id)
+        self.verify(
+            expression=exists is False,
+            error_code=a.const.ERROR_ALREADY_EXISTS_ID,
+            message=f'An error with ID {id} already exists.',
+            id=id
+        )
+
+        # Create the Error aggregate.
+        error_messages = [{'lang': lang, 'text': message}] + additional_messages
+        new_error = Aggregate.new(
+            ErrorAggregate,
+            id=id,
+            name=name,
+            message=error_messages
+        )
+
+        # Save the new error.
+        self.error_service.save(new_error)
+
+        # Return the new error.
+        return new_error

--- a/samples/empty_events.py
+++ b/samples/empty_events.py
@@ -1,0 +1,12 @@
+"""Tiferet Empty Events Sample — imports section with no event definitions"""
+
+# *** imports
+
+# ** core
+from typing import Any
+
+# ** app
+from .settings import DomainEvent, a
+from ..interfaces import ErrorService
+
+# *** events

--- a/samples/error_events.py
+++ b/samples/error_events.py
@@ -1,0 +1,386 @@
+"""Tiferet Error Domain Events."""
+
+# *** imports
+
+# ** core
+from typing import (
+    List,
+    Dict,
+    Any
+)
+
+# ** app
+from .settings import DomainEvent, a
+from ..domain import Error
+from ..interfaces import ErrorService
+from ..mappers import Aggregate, ErrorAggregate
+
+# *** events
+
+# ** event: add_error
+class AddError(DomainEvent):
+    """
+    Command to add a new Error domain object to the repository.
+    """
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        """
+        Initialize the AddError command.
+
+        :param error_repo: The error service to use.
+        :type error_repo: ErrorService
+        """
+        self.error_service = error_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id', 'name', 'message'])
+    def execute(self,id: str, name: str, message: str, lang: str = 'en_US', additional_messages: List[Dict[str, Any]] = []) -> None:
+        """
+        Add a new Error to the app.
+
+        :param id: The unique identifier of the error.
+        :type id: str
+        :param name: The name of the error.
+        :type name: str
+        :param message: The primary error message text.
+        :type message: str
+        :param lang: The language of the primary error message (default is 'en_US').
+        :type lang: str
+        :param additional_messages: Additional error messages in different languages.
+        :type additional_messages: List[Dict[str, Any]]
+        """
+
+        # Check if an error with the same ID already exists.
+        exists = self.error_service.exists(id)
+        self.verify(
+            expression=exists is False,
+            error_code=a.const.ERROR_ALREADY_EXISTS_ID,
+            message=f'An error with ID {id} already exists.',
+            id=id
+        )
+
+        # Create the Error aggregate.
+        error_messages = [{'lang': lang, 'text': message}] + additional_messages
+        new_error = Aggregate.new(
+            ErrorAggregate,
+            id=id,
+            name=name,
+            message=error_messages
+        )
+
+        # Save the new error.
+        self.error_service.save(new_error)
+
+        # Return the new error.
+        return new_error
+
+# ** event: get_error
+class GetError(DomainEvent):
+    """
+    Command to retrieve an Error domain object by its ID.
+    """
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        """
+        Initialize the GetError command.
+
+        :param error_repo: The error service to use.
+        :type error_repo: ErrorService
+        """
+        self.error_service = error_service
+
+    # * method: execute
+    def execute(self, id: str, include_defaults: bool = False, **kwargs) -> Error:
+        """
+        Retrieve an Error by its ID.
+
+        :param id: The unique identifier of the error.
+        :type id: str
+        :param include_defaults: If True, search DEFAULT_ERRORS if not found in repository.
+        :type include_defaults: bool
+        :param kwargs: Additional context (passed to error if raised).
+        :type kwargs: dict
+        :return: The Error domain model instance.
+        :rtype: Error
+        """
+
+        # Attempt to retrieve from configured repository.
+        error = self.error_service.get(id)
+
+        # If found, return immediately.
+        if error:
+            return error
+
+        # If requested, check built-in defaults and return as error aggregate if found.
+        if include_defaults:
+            error_data = a.DEFAULT_ERRORS.get(id)
+            if error_data:
+                return Aggregate.new(ErrorAggregate, **error_data)
+
+        # If still not found and defaults not included, raise structured error.
+        self.raise_error(
+            error_code=a.ERROR_NOT_FOUND_ID,
+            message=f'Error not found: {id}.',
+            id=id,
+        )
+
+# ** event: list_errors
+class ListErrors(DomainEvent):
+    """
+    Command to list all Error domain objects.
+    """
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        """
+        Initialize the ListErrors command.
+
+        :param error_repo: The error service to use.
+        :type error_repo: ErrorService
+        """
+        self.error_service = error_service
+
+    # * method: execute
+    def execute(self, include_defaults: bool = False, **kwargs) -> List[Error]:
+        """
+        List all Errors.
+
+        :return: The list of Error domain model instances.
+        :rtype: List[Error]
+        :param include_defaults: If True, include DEFAULT_ERRORS in the list.
+        :type include_defaults: bool
+        :param kwargs: Additional context (passed to error if raised).
+        :type kwargs: dict
+        """
+
+        # If defaults are not included, retrieve from repository only.
+        if not include_defaults:
+            return self.error_service.list()
+        
+        # If defaults are included, merge repository and default errors.
+        errors = {id: Aggregate.new(ErrorAggregate, **data) for id, data in a.const.DEFAULT_ERRORS.items()}
+        repo_errors = self.error_service.list()
+        errors.update({error.id: error for error in repo_errors})
+
+        # Return the merged list of errors.
+        return list(errors.values())
+
+# ** event: rename_error
+class RenameError(DomainEvent):
+    """
+    Command to rename an existing Error domain object.
+    """
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        """
+        Initialize the RenameError command.
+
+        :param error_repo: The error service to use.
+        :type error_repo: ErrorService
+        """
+        self.error_service = error_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['new_name'])
+    def execute(self, id: str, new_name: str, **kwargs) -> Error:
+        """
+        Rename an existing Error by its ID.
+
+        :param id: The unique identifier of the error to rename.
+        :type id: str
+        :param new_name: The new name for the error.
+        :type new_name: str
+        :param kwargs: Additional context (passed to error if raised).
+        :type kwargs: dict
+        :return: The updated Error domain model instance.
+        :rtype: Error
+        """
+
+        # Retrieve the existing error.
+        error = self.error_service.get(id)
+
+        # Verify that the error exists.
+        self.verify(
+            expression=error,
+            error_code=a.const.ERROR_NOT_FOUND_ID,
+            message=f'Error not found: {id}.',
+            id=id
+        )
+
+        # Update the name.
+        error.rename(new_name)
+
+        # Save the updated error.
+        self.error_service.save(error)
+
+        # Return the updated error.
+        return error
+
+# ** event: set_error_message
+class SetErrorMessage(DomainEvent):
+    """
+    Command to set the message of an existing Error domain object.
+    """
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        """
+        Initialize the SetErrorMessage command.
+
+        :param error_repo: The error service to use.
+        :type error_repo: ErrorService
+        """
+        self.error_service = error_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['message'])
+    def execute(self, id: str, message: str, lang: str = 'en_US', **kwargs) -> str:
+        """
+        Set the message of an existing Error by its ID.
+
+        :param id: The unique identifier of the error.
+        :type id: str
+        :param message: The new message text.
+        :type message: str
+        :param lang: The language of the message (default is 'en_US').
+        :type lang: str
+        :param kwargs: Additional context (passed to error if raised).
+        :type kwargs: dict
+        :return: The unique identifier of the updated error.
+        :rtype: str
+        """
+
+        # Retrieve the existing error.
+        error = self.error_service.get(id)
+
+        # Verify that the error exists.
+        self.verify(
+            expression=error,
+            error_code=a.const.ERROR_NOT_FOUND_ID,
+            message=f'Error not found: {id}.',
+            id=id
+        )
+
+        # Update the message.
+        error.set_message(lang, message)
+
+        # Save the updated error.
+        self.error_service.save(error)
+
+        # Return the updated error id.
+        return id
+
+# ** event: remove_error_message
+class RemoveErrorMessage(DomainEvent):
+    """
+    Command to remove a message from an existing Error domain object.
+    """
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        """
+        Initialize the RemoveErrorMessage command.
+
+        :param error_repo: The error service to use.
+        :type error_repo: ErrorService
+        """
+        self.error_service = error_service
+
+    # * method: execute
+    def execute(self, id: str, lang: str = 'en_US', **kwargs) -> str:
+        """
+        Remove a message from an existing Error by its ID.
+
+        :param id: The unique identifier of the error.
+        :type id: str
+        :param lang: The language of the message to remove (default is 'en_US').
+        :type lang: str
+        :param kwargs: Additional context (passed to error if raised).
+        :type kwargs: dict
+        :return: The unique identifier of the updated error.
+        :rtype: str
+        """
+
+        # Retrieve the existing error.
+        error = self.error_service.get(id)
+        self.verify(
+            expression=error,
+            error_code=a.const.ERROR_NOT_FOUND_ID,
+            message=f'Error not found: {id}.',
+            id=id
+        )
+
+        # Remove the message.
+        error.remove_message(lang)
+
+        # Verify that at least one message remains.
+        self.verify(
+            expression=len(error.message) > 0,
+            error_code=a.const.NO_ERROR_MESSAGES_ID,
+            message=f'No error messages are defined for error ID {id}.',
+            id=id
+        )
+
+        # Save the updated error.
+        self.error_service.save(error)
+
+        # Return the updated error id.
+        return id
+
+# ** event: remove_error
+class RemoveError(DomainEvent):
+    """
+    Command to remove an existing Error domain object by its ID.
+    """
+    
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        """
+        Initialize the RemoveError command.
+
+        :param error_repo: The error service to use.
+        :type error_repo: ErrorService
+        """
+        self.error_service = error_service
+
+    # * method: execute
+    @DomainEvent.parameters_required(['id'])
+    def execute(self, id: str, **kwargs) -> None:
+        """
+        Remove an existing Error by its ID.
+
+        :param id: The unique identifier of the error to remove.
+        :type id: str
+        :param kwargs: Additional context (passed to error if raised).
+        :type kwargs: dict
+        """
+
+        # Remove the error.
+        self.error_service.delete(id)
+
+        # Return the removed error id.
+        return id

--- a/samples/invalid_annotation_event.py
+++ b/samples/invalid_annotation_event.py
@@ -1,0 +1,58 @@
+"""Tiferet Invalid Annotation Sample — malformed obsolete and todo annotations"""
+
+# *** imports
+
+# ** app
+from .settings import DomainEvent, a
+from ..interfaces import ErrorService
+
+# *** events
+
+# ** event: get_error
+# -- obsolete
+class GetError(DomainEvent):
+    '''
+    An event with a malformed group-level obsolete annotation.
+    The annotation is missing a colon and description, so the lexer
+    emits LINE_COMMENT instead of OBSOLETE.
+    '''
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        '''
+        Initialize the GetError event.
+
+        :param error_service: The error service.
+        :type error_service: ErrorService
+        '''
+
+        # Set the error service dependency.
+        self.error_service = error_service
+
+    # * method: execute
+    # + todo
+    def execute(self, id: str, **kwargs):
+        '''
+        Retrieve an error by its ID.
+
+        :param id: The error identifier.
+        :type id: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        '''
+
+        # Retrieve the error from the service.
+        error = self.error_service.get(id)
+
+        # Verify the error exists.
+        self.verify(
+            expression=error is not None,
+            error_code=a.const.ERROR_NOT_FOUND_ID,
+            id=id,
+        )
+
+        # Return the error.
+        return error

--- a/samples/invalid_identifier_names_event.py
+++ b/samples/invalid_identifier_names_event.py
@@ -1,0 +1,92 @@
+"""Tiferet Invalid Identifier Names Sample — digit-prefixed class, attribute, and method names"""
+
+# *** imports
+
+# ** core
+from typing import Any
+
+# ** app
+from .settings import DomainEvent, a
+from ..interfaces import ErrorService
+
+# *** events
+
+# ** event: 123add_error
+class 123AddError(DomainEvent):
+    '''
+    An intentionally malformed event class with a digit-prefixed name.
+    The lexer should emit CLASS UNKNOWN LPAREN for this declaration.
+    '''
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        '''
+        Initialize the event.
+
+        :param error_service: The error service.
+        :type error_service: ErrorService
+        '''
+
+        # Set the error service dependency.
+        self.error_service = error_service
+
+    # * method: execute
+    def execute(self, id: str, **kwargs) -> None:
+        '''
+        Attempt to add an error.
+
+        :param id: The error identifier.
+        :type id: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        '''
+
+        # Verify the error does not already exist.
+        self.verify(
+            expression=not self.error_service.exists(id),
+            error_code=a.const.ERROR_ALREADY_EXISTS_ID,
+            id=id,
+        )
+
+        # Save the error.
+        self.error_service.save(id=id)
+
+
+# ** event: bad_members
+class BadMembers(DomainEvent):
+    '''
+    An event with intentionally malformed attribute and method names.
+    The lexer should emit UNKNOWN tokens for digit-prefixed members.
+    '''
+
+    # * attribute: 456error_service
+    456error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        '''
+        Initialize the event.
+
+        :param error_service: The error service.
+        :type error_service: ErrorService
+        '''
+
+        # Set the attribute with a digit-prefixed name.
+        self.456error_service = error_service
+
+    # * method: 789execute
+    def 789execute(self, id: str, **kwargs) -> None:
+        '''
+        A method with a digit-prefixed name.
+
+        :param id: The identifier.
+        :type id: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        '''
+
+        # Attempt to use the malformed attribute.
+        self.456error_service.exists(id)

--- a/samples/obsolete_rename_error_event.py
+++ b/samples/obsolete_rename_error_event.py
@@ -1,0 +1,63 @@
+"""Tiferet RenameError Event Sample — Obsolete Annotations"""
+
+# *** imports
+
+# ** app
+from .settings import DomainEvent, a
+from ..interfaces import ErrorService
+
+# *** events
+
+# ** event: rename_error
+# -- obsolete: superseded by ErrorAggregate.rename(); use UpdateError instead
+class RenameError(DomainEvent):
+    """
+    Command to rename an existing Error domain object.
+    """
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        """
+        Initialize the RenameError command.
+
+        :param error_service: The error service to use.
+        :type error_service: ErrorService
+        """
+        self.error_service = error_service
+
+    # * method: execute
+    # - obsolete: inline rename logic; delegate to error_service.rename() instead
+    def execute(self, id: str, name: str, **kwargs) -> str:
+        """
+        Rename an existing Error by its ID.
+
+        :param id: The unique identifier of the error.
+        :type id: str
+        :param name: The new name for the error.
+        :type name: str
+        :param kwargs: Additional context.
+        :type kwargs: dict
+        :return: The unique identifier of the updated error.
+        :rtype: str
+        """
+
+        # Retrieve the existing error.
+        error = self.error_service.get(id)
+        self.verify(
+            expression=error is not None,
+            error_code=a.const.ERROR_NOT_FOUND_ID,
+            message=f'Error not found: {id}.',
+            id=id
+        )
+
+        # Rename the error.
+        error.set_attribute('name', name)
+
+        # Save the updated error.
+        self.error_service.save(error)
+
+        # Return the updated error id.
+        return id

--- a/samples/todo_get_error_event.py
+++ b/samples/todo_get_error_event.py
@@ -1,0 +1,58 @@
+"""Tiferet GetError Event Sample — TODO Annotations"""
+
+# *** imports
+
+# ** app
+from .settings import DomainEvent, a
+from ..domain import Error
+from ..interfaces import ErrorService
+
+# *** events
+
+# ** event: get_error
+# ++ todo: add CacheService injection to cache retrieved errors
+class GetError(DomainEvent):
+    """
+    Command to retrieve an existing Error domain object by its ID.
+    """
+
+    # * attribute: error_service
+    error_service: ErrorService
+
+    # * init
+    def __init__(self, error_service: ErrorService):
+        """
+        Initialize the GetError command.
+
+        :param error_service: The error service to use.
+        :type error_service: ErrorService
+        """
+        self.error_service = error_service
+
+    # * method: execute
+    # + todo: validate lang parameter against supported locales before retrieval
+    def execute(self, id: str, **kwargs) -> Error:
+        """
+        Retrieve an Error by its ID.
+
+        :param id: The unique identifier of the error.
+        :type id: str
+        :param kwargs: Additional context.
+        :type kwargs: dict
+        :return: The retrieved Error domain object.
+        :rtype: Error
+        """
+
+        # Retrieve the error from the service.
+        error = self.error_service.get(id)
+
+        # Verify the error exists.
+        self.verify(
+            expression=error is not None,
+            error_code=a.const.ERROR_NOT_FOUND_ID,
+            message=f'Error not found: {id}.',
+            id=id
+        )
+
+        # Return the retrieved error.
+        return error

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -9,4 +9,4 @@ from .utils import TiferetLexer
 
 # *** version
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'


### PR DESCRIPTION
## Summary

Implements TRD #25 — the formal release story for v0.2.0. Bumps the version, introduces dynamic versioning, updates all documentation to reflect the v0.2.0 state, and adds the expanded sample set.

## Changes

### Version
- `src/__init__.py`: `__version__` bumped from `0.1.0` → `0.2.0`
- `pyproject.toml`: replaced static `version = "0.1.0"` with `dynamic = ["version"]` + `[tool.setuptools.dynamic]` section reading from `src.__version__`
- `.gitignore`: removed `samples/` entry (was preventing sample files from being tracked)

### `README.md`
- Token categories: removed Domain Idioms and `EXECUTE`; added Annotation Markers (`OBSOLETE`, `TODO`), Operators (20 tokens), Layout & Indentation (`INDENT`, `DEDENT`)
- Added Sample Files table (5 success / 2 failure cases)
- Test counts: 54 → 96; added per-file test run commands
- Project structure: added `docs/guides/`, `src/assets/`, new utils, expanded `samples/`
- Docs link: `LEXICAL_SPEC.md` → `docs/guides/lexical_spec.md`
- Development status: branch `master` → `v0.2-release`, version `0.1.0` → `0.2.0`

### `AGENTS.md`
- Version `0.1.0` → `0.2.0`, branch `master` → `v0.2-release`
- Pipeline: updated `PerformLexicalAnalysis` description to include `IndentInjector`
- Project structure: added `docs/guides/`, `src/assets/`, new utility files, expanded samples; removed `Scanner/` section
- Key Files: added `indent.py`, `parser.py`, `output.py` sections; updated lexer token list to 53 tokens
- Test count: 54 → 96

### `samples/` (new — 7 files)
- **Success:** `empty_events.py`, `add_error_event.py`, `error_events.py`, `obsolete_rename_error_event.py`, `todo_get_error_event.py`
- **Failure:** `invalid_identifier_names_event.py`, `invalid_annotation_event.py`

## Acceptance Criteria
- [x] `__version__ == '0.2.0'` in `src/__init__.py`
- [x] `pyproject.toml` uses dynamic versioning sourced from `src.__version__`
- [x] `README.md` and `AGENTS.md` reflect v0.2.0 state
- [x] 7 sample files present in `samples/`
- [x] All 96 tests passing

Closes #25