### PR TITLE
Parser – Implement TiferetParser Utility with Dynamic PLY yacc Loading (#35)

### DIFF
--- a/src/assets/parser.py
+++ b/src/assets/parser.py
@@ -12,6 +12,8 @@ TOKENS = _lexer.TOKENS
 
 # ** constant: precedence
 precedence = (
+    ('right', 'COLON'),
+    ('right', 'ARROW'),
     ('nonassoc', 'ARTIFACT_START', 'ARTIFACT_SECTION', 'ARTIFACT_MEMBER',
                  'OBSOLETE', 'TODO', 'DEDENT'),
 )

--- a/src/interfaces/__init__.py
+++ b/src/interfaces/__init__.py
@@ -2,3 +2,4 @@
 
 # ** app
 from .lexer import LexerService
+from .parser import ParserService

--- a/src/interfaces/parser.py
+++ b/src/interfaces/parser.py
@@ -1,0 +1,32 @@
+"""Scanner Parser Interface"""
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import List, Dict, Any
+
+# ** infra
+from tiferet.interfaces.settings import Service
+
+# *** interfaces
+
+# ** interface: parser_service
+class ParserService(Service):
+    '''
+    Abstract interface for syntactic analysis of tokenized Tiferet Domain Event dialect input.
+    '''
+
+    # * method: parse
+    @abstractmethod
+    def parse(self, tokens: List[Dict[str, Any]]) -> Dict[str, Any]:
+        '''
+        Parse a list of tokens into a structured AST reflecting the three-tier artifact hierarchy.
+
+        :param tokens: Token stream from lexer + IndentInjector (including synthetic INDENT/DEDENT).
+        :type tokens: List[Dict[str, Any]]
+        :return: Root Module AST node.
+        :rtype: Dict[str, Any]
+        '''
+
+        raise NotImplementedError()

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -4,6 +4,7 @@
 
 # ** app
 from .lexer import TiferetLexer
+from .parser import TiferetParser
 from .artifact import ArtifactBlockParser
 from .output import ScanOutputWriter
 from .indent import IndentInjector

--- a/src/utils/parser.py
+++ b/src/utils/parser.py
@@ -1,0 +1,577 @@
+"""Scanner Parser Utility"""
+
+# *** imports
+
+# ** core
+from types import MethodType
+from typing import List, Dict, Any
+
+# ** infra
+import ply.yacc as yacc
+
+# ** app
+from ..events import a
+from ..interfaces import ParserService
+
+# *** utils
+
+# ** util: tiferet_parser
+class TiferetParser(ParserService):
+    '''
+    PLY yacc-based syntactic parser for the Tiferet Domain Event dialect.
+    Implements ParserService and dynamically loads grammar from assets,
+    exactly mirroring the TiferetLexer pattern.
+    '''
+
+    # * attribute: parser
+    parser: Any
+
+    # -- PLY token list (sourced from assets)
+    tokens = a.parser.TOKENS
+
+    # -- PLY precedence (sourced from assets)
+    precedence = a.parser.precedence
+
+    # * init
+    def __init__(self):
+        '''
+        Initialize the TiferetParser by dynamically attaching grammar rules
+        and building the PLY yacc instance.
+        '''
+
+        # Load rules dynamically from the assets mapping (mirrors lexer).
+        for name, rule in a.parser.RULES.items():
+            if callable(rule):
+                setattr(self, name, MethodType(rule, self))
+            else:
+                # String BNF rule — create a wrapper with __doc__ set to the production.
+                handler = _build_semantic_action(name, rule)
+                setattr(self, name, MethodType(handler, self))
+
+        # Build the PLY yacc parser.
+        self.parser = yacc.yacc(module=self, start='module', debug=False, write_tables=False)
+
+    # * method: parse
+    def parse(self, tokens: List[Dict[str, Any]]) -> Dict[str, Any]:
+        '''
+        Parse a list of token dictionaries (post-IndentInjector) into AST.
+
+        :param tokens: Token stream with 'type' and 'value' keys.
+        :type tokens: List[Dict[str, Any]]
+        :return: Structured AST dict reflecting the three-tier artifact hierarchy.
+        :rtype: Dict[str, Any]
+        '''
+
+        # Create a thin adapter so PLY can consume our List[Dict] token stream.
+        stream = TokenStream(tokens)
+
+        # Parse the token stream and return the AST.
+        return self.parser.parse(lexer=stream)
+
+    # * rule: error
+    def p_error(self, p):
+        '''
+        Report syntax errors using Tiferet artifact hierarchy terminology.
+        '''
+
+        if p:
+            raise SyntaxError(
+                f"Syntax error in Tiferet artifact hierarchy: "
+                f"unexpected token '{p.type}' "
+                f"(value={p.value!r}, line {getattr(p, 'lineno', '?')}). "
+                f"Expected a valid # *** Group, # ** Section, or # * Member structure."
+            )
+        else:
+            raise SyntaxError(
+                "Unexpected end of input while parsing Tiferet Domain Event structure. "
+                "Ensure all # *** Group, # ** Section, and # * Member blocks are complete."
+            )
+
+
+# *** classes
+
+# ** class: token_stream
+class TokenStream:
+    '''
+    Thin adapter that feeds a List[Dict] token stream to PLY's yacc parser.
+    PLY calls stream.token() repeatedly until it returns None.
+    '''
+
+    # * init
+    def __init__(self, tokens: List[Dict[str, Any]]):
+        '''
+        Initialize the token stream adapter.
+
+        :param tokens: The list of token dictionaries from the lexer + IndentInjector.
+        :type tokens: List[Dict[str, Any]]
+        '''
+
+        self._iter = iter(tokens)
+
+    # * method: token
+    def token(self):
+        '''
+        Return the next token as a PLY-compatible object, or None at end of stream.
+
+        :return: A PLY-compatible token object or None.
+        :rtype: object | None
+        '''
+
+        try:
+            t = next(self._iter)
+            tok = PLYToken()
+            tok.type = t['type']
+            tok.value = t.get('value')
+            tok.lineno = t.get('line', 0)
+            tok.lexpos = t.get('column', 0)
+            return tok
+        except StopIteration:
+            return None
+
+
+# ** class: ply_token
+class PLYToken:
+    '''
+    Minimal PLY-compatible token object used by TokenStream.
+    '''
+
+    # * attribute: type
+    type: str
+
+    # * attribute: value
+    value: Any
+
+    # * attribute: lineno
+    lineno: int
+
+    # * attribute: lexpos
+    lexpos: int
+
+
+# *** helpers
+
+# ** helper: _build_semantic_action
+def _build_semantic_action(name: str, rule_str: str):
+    '''
+    Build a semantic action function for a string-based BNF rule.
+    The function dispatches to the appropriate AST builder from the parser assets
+    based on the rule name.
+
+    :param name: The PLY rule function name (e.g. 'p_module', 'p_group').
+    :type name: str
+    :param rule_str: The BNF production string used as __doc__.
+    :type rule_str: str
+    :return: A semantic action function with __doc__ set to the production.
+    :rtype: callable
+    '''
+
+    # Resolve the semantic action based on the rule name.
+    action = _SEMANTIC_ACTIONS.get(name, _default_action)
+
+    # Wrap the action with the production docstring.
+    def p_func(self, p):
+        action(p)
+    p_func.__doc__ = rule_str
+
+    return p_func
+
+
+# ** helper: _default_action
+def _default_action(p):
+    '''
+    Default semantic action: pass through the first symbol's value.
+
+    :param p: The PLY production object.
+    :type p: yacc.YaccProduction
+    '''
+
+    p[0] = p[1]
+
+
+# ** helper: _collect_list
+def _collect_list(p):
+    '''
+    Collect list items via left-recursive accumulation.
+    Used for GroupList, SectionList, MemberList, SnippetList, StmtList.
+
+    :param p: The PLY production object.
+    :type p: yacc.YaccProduction
+    '''
+
+    p[0] = p[1] + [p[2]]
+
+
+# ** helper: _empty_list
+def _empty_list(p):
+    '''
+    Initialize an empty list for left-recursive base cases.
+
+    :param p: The PLY production object.
+    :type p: yacc.YaccProduction
+    '''
+
+    p[0] = []
+
+
+# *** semantic_actions
+
+# ** actions: tier 1 — module / artifact groups
+
+def _action_module(p):
+    '''Build Module AST node from group list.'''
+    p[0] = a.parser.build_module(p[1])
+
+def _action_group(p):
+    '''Build Group AST node: header NEWLINE section_list.'''
+    p[0] = a.parser.build_group(p[1], p[3])
+
+def _action_group_header(p):
+    '''Pass through the group header token value.'''
+    p[0] = p[1]
+
+# ** actions: tier 2 — artifact sections
+
+def _action_section(p):
+    '''Build Section AST node: header NEWLINE body.'''
+    p[0] = a.parser.build_section(p[1], p[3])
+
+def _action_section_annotated(p):
+    '''Build Section AST node with annotations: annots header NEWLINE body.'''
+    p[0] = a.parser.build_section(p[2], p[4], annotations=p[1])
+
+def _action_section_header(p):
+    '''Pass through the section header token value.'''
+    p[0] = p[1]
+
+def _action_annots_single(p):
+    '''Start an annotation list from a single annotation.'''
+    p[0] = [p[1]]
+
+def _action_annots_multi(p):
+    '''Extend an annotation list with an additional annotation.'''
+    p[0] = p[1] + [p[2]]
+
+def _action_annot_obsolete(p):
+    '''Build OBSOLETE annotation node.'''
+    p[0] = a.parser.build_annot('OBSOLETE', p[1])
+
+def _action_annot_todo(p):
+    '''Build TODO annotation node.'''
+    p[0] = a.parser.build_annot('TODO', p[1])
+
+# ** actions: section body
+
+def _action_section_body(p):
+    '''Pass through the section body (ClassDef, FuncDef, or ImportBlock).'''
+    p[0] = p[1]
+
+def _action_import_block_single(p):
+    '''Start an import block with a single import statement.'''
+    p[0] = {'type': 'ImportBlock', 'statements': [p[1]]}
+
+def _action_import_block_multi(p):
+    '''Extend an import block with an additional import statement.'''
+    p[1]['statements'].append(p[2])
+    p[0] = p[1]
+
+def _action_import_stmt(p):
+    '''Build ImportStmt: PYTHON_KEYWORD token_seq NEWLINE.'''
+    p[0] = a.parser.build_import_stmt(p[1], p[2])
+
+# ** actions: class definition
+
+def _action_class_def(p):
+    '''Build ClassDef: CLASS IDENTIFIER LPAREN name_list RPAREN COLON NEWLINE INDENT class_body DEDENT.'''
+    p[0] = a.parser.build_class_def(
+        name=p[2],
+        bases=p[4],
+        body=p[9]['members'],
+        docstring=p[9].get('docstring'),
+    )
+
+def _action_class_body_doc(p):
+    '''Build ClassBody with docstring: DOCSTRING NEWLINE member_list.'''
+    p[0] = {'docstring': p[1], 'members': p[3]}
+
+def _action_class_body_nodoc(p):
+    '''Build ClassBody without docstring: member_list.'''
+    p[0] = {'docstring': None, 'members': p[1]}
+
+def _action_name_list_single(p):
+    '''Start a name list with a single identifier.'''
+    p[0] = [p[1]]
+
+def _action_name_list_multi(p):
+    '''Extend a name list: name_list COMMA IDENTIFIER.'''
+    p[0] = p[1] + [p[3]]
+
+# ** actions: tier 3 — artifact members
+
+def _action_member(p):
+    '''Build Member AST node: ARTIFACT_MEMBER NEWLINE member_body.'''
+    kind = _parse_member_kind(p[1])
+    p[0] = a.parser.build_member(kind, p[3])
+
+def _action_member_annotated(p):
+    '''Build Member AST node with annotations: annots ARTIFACT_MEMBER NEWLINE member_body.'''
+    kind = _parse_member_kind(p[2])
+    p[0] = a.parser.build_member(kind, p[4], annotations=p[1])
+
+def _action_member_body(p):
+    '''Pass through the member body (AttrDecl or MethodDef).'''
+    p[0] = p[1]
+
+def _action_attr_decl(p):
+    '''Build AttrDecl: IDENTIFIER COLON token_seq NEWLINE.'''
+    p[0] = a.parser.build_attr_decl(p[1], p[3])
+
+# ** actions: method definition
+
+def _action_method_def(p):
+    '''Build MethodDef: DEF method_name LPAREN SELF param_tail RPAREN ret_annot COLON NEWLINE INDENT body DEDENT.'''
+    p[0] = a.parser.build_method_def(
+        name=p[2],
+        params=p[5],
+        body=p[11]['snippets'],
+        return_type=p[7],
+        docstring=p[11].get('docstring'),
+    )
+
+def _action_method_def_decorated(p):
+    '''Build decorated MethodDef: decorator DEF method_name LPAREN SELF param_tail RPAREN ret_annot COLON NEWLINE INDENT body DEDENT.'''
+    p[0] = a.parser.build_method_def(
+        name=p[3],
+        params=p[6],
+        body=p[12]['snippets'],
+        return_type=p[8],
+        decorator=p[1],
+        docstring=p[12].get('docstring'),
+    )
+
+def _action_method_name(p):
+    '''Pass through method name (IDENTIFIER or INIT).'''
+    p[0] = p[1]
+
+def _action_param_tail(p):
+    '''Build param tail: COMMA token_seq.'''
+    p[0] = p[2]
+
+def _action_param_tail_empty(p):
+    '''Build empty param tail.'''
+    p[0] = []
+
+def _action_ret_annot(p):
+    '''Build return annotation: ARROW token_seq.'''
+    p[0] = p[2]
+
+def _action_ret_annot_empty(p):
+    '''Build empty return annotation.'''
+    p[0] = None
+
+def _action_decorator(p):
+    '''Build Decorator: AT token_seq NEWLINE.'''
+    p[0] = a.parser.build_decorator(p[2])
+
+# ** actions: function definition
+
+def _action_func_def(p):
+    '''Build FuncDef: DEF IDENTIFIER LPAREN param_body RPAREN ret_annot COLON NEWLINE INDENT body DEDENT.'''
+    p[0] = a.parser.build_func_def(
+        name=p[2],
+        params=p[4],
+        body=p[10]['snippets'],
+        return_type=p[6],
+        docstring=p[10].get('docstring'),
+    )
+
+def _action_func_def_decorated(p):
+    '''Build decorated FuncDef: decorator DEF IDENTIFIER LPAREN param_body RPAREN ret_annot COLON NEWLINE INDENT body DEDENT.'''
+    p[0] = a.parser.build_func_def(
+        name=p[3],
+        params=p[5],
+        body=p[11]['snippets'],
+        return_type=p[7],
+        decorator=p[1],
+        docstring=p[11].get('docstring'),
+    )
+
+def _action_param_body(p):
+    '''Build param body: token_seq.'''
+    p[0] = p[1]
+
+def _action_param_body_empty(p):
+    '''Build empty param body.'''
+    p[0] = []
+
+# ** actions: body / snippets
+
+def _action_body_doc(p):
+    '''Build Body with docstring: DOCSTRING NEWLINE snippet_list.'''
+    p[0] = a.parser.build_body(p[3], docstring=p[1])
+
+def _action_body_nodoc(p):
+    '''Build Body without docstring: snippet_list.'''
+    p[0] = a.parser.build_body(p[1])
+
+def _action_snippet_comment(p):
+    '''Build Snippet with comment: LINE_COMMENT NEWLINE stmt_list.'''
+    p[0] = a.parser.build_snippet(p[3], comment=p[1])
+
+def _action_snippet_nocomment(p):
+    '''Build Snippet without comment: stmt_list.'''
+    p[0] = a.parser.build_snippet(p[1])
+
+def _action_stmt_simple(p):
+    '''Build simple Stmt: token_seq NEWLINE.'''
+    p[0] = a.parser.build_stmt(p[1])
+
+def _action_stmt_compound(p):
+    '''Build compound Stmt: token_seq NEWLINE INDENT stmt_list DEDENT.'''
+    p[0] = a.parser.build_stmt(p[1], block=p[4])
+
+# ** actions: token sequence
+
+def _action_token_seq_single(p):
+    '''Start a token sequence with a single item.'''
+    p[0] = [p[1]]
+
+def _action_token_seq_multi(p):
+    '''Extend a token sequence with an additional item.'''
+    p[0] = p[1] + [p[2]]
+
+def _action_token_item(p):
+    '''Pass through a token item (Token or Enclosed).'''
+    p[0] = p[1]
+
+def _action_enclosed(p):
+    '''Build Enclosed: open inner close.'''
+    p[0] = a.parser.build_enclosed(p[1], p[2], p[3])
+
+def _action_inner(p):
+    '''Extend inner items: inner inner_item.'''
+    p[0] = p[1] + [p[2]]
+
+def _action_inner_empty(p):
+    '''Initialize empty inner.'''
+    p[0] = []
+
+def _action_inner_item(p):
+    '''Pass through inner item (token_item or NEWLINE).'''
+    p[0] = p[1]
+
+def _action_token(p):
+    '''Pass through a content terminal value.'''
+    p[0] = p[1]
+
+
+# ** helper: _parse_member_kind
+def _parse_member_kind(artifact_member_value: str) -> str:
+    '''
+    Extract the member kind from an ARTIFACT_MEMBER token value.
+    E.g. "# * attribute: error_service" -> "attribute",
+         "# * init" -> "init",
+         "# * method: execute" -> "method".
+
+    :param artifact_member_value: The raw ARTIFACT_MEMBER token value.
+    :type artifact_member_value: str
+    :return: The member kind string.
+    :rtype: str
+    '''
+
+    # Strip the "# * " prefix and extract the first word.
+    stripped = artifact_member_value.lstrip('# *').strip()
+    kind = stripped.split(':')[0].split()[0] if stripped else 'unknown'
+    return kind
+
+
+# ** constant: semantic_actions
+_SEMANTIC_ACTIONS = {
+    # -- Tier 1: Module / Artifact Groups --
+    'p_module': _action_module,
+    'p_group_list': _collect_list,
+    'p_group_list_empty': _empty_list,
+    'p_group': _action_group,
+    'p_group_header_imports': _action_group_header,
+    'p_group_header_start': _action_group_header,
+
+    # -- Tier 2: Artifact Sections --
+    'p_section_list': _collect_list,
+    'p_section_list_empty': _empty_list,
+    'p_section': _action_section,
+    'p_section_annotated': _action_section_annotated,
+    'p_section_header_section': _action_section_header,
+    'p_section_header_import': _action_section_header,
+    'p_annots_single': _action_annots_single,
+    'p_annots_multi': _action_annots_multi,
+    'p_annot_obsolete': _action_annot_obsolete,
+    'p_annot_todo': _action_annot_todo,
+
+    # -- Section Body --
+    'p_section_body_class': _action_section_body,
+    'p_section_body_func': _action_section_body,
+    'p_section_body_import': _action_section_body,
+    'p_import_block_single': _action_import_block_single,
+    'p_import_block_multi': _action_import_block_multi,
+    'p_import_stmt': _action_import_stmt,
+
+    # -- Class Definition --
+    'p_class_def': _action_class_def,
+    'p_class_body_doc': _action_class_body_doc,
+    'p_class_body_nodoc': _action_class_body_nodoc,
+    'p_name_list_single': _action_name_list_single,
+    'p_name_list_multi': _action_name_list_multi,
+
+    # -- Tier 3: Artifact Members --
+    'p_member_list': _collect_list,
+    'p_member_list_empty': _empty_list,
+    'p_member': _action_member,
+    'p_member_annotated': _action_member_annotated,
+    'p_member_body_attr': _action_member_body,
+    'p_member_body_method': _action_member_body,
+    'p_attr_decl': _action_attr_decl,
+
+    # -- Method Definition --
+    'p_method_def': _action_method_def,
+    'p_method_def_decorated': _action_method_def_decorated,
+    'p_method_name_id': _action_method_name,
+    'p_method_name_init': _action_method_name,
+    'p_param_tail': _action_param_tail,
+    'p_param_tail_empty': _action_param_tail_empty,
+    'p_ret_annot': _action_ret_annot,
+    'p_ret_annot_empty': _action_ret_annot_empty,
+    'p_decorator': _action_decorator,
+
+    # -- Function Definition --
+    'p_func_def': _action_func_def,
+    'p_func_def_decorated': _action_func_def_decorated,
+    'p_param_body': _action_param_body,
+    'p_param_body_empty': _action_param_body_empty,
+
+    # -- Body / Snippets --
+    'p_body_doc': _action_body_doc,
+    'p_body_nodoc': _action_body_nodoc,
+    'p_snippet_list': _collect_list,
+    'p_snippet_list_empty': _empty_list,
+    'p_snippet_comment': _action_snippet_comment,
+    'p_snippet_nocomment': _action_snippet_nocomment,
+    'p_stmt_list': _collect_list,
+    'p_stmt_list_empty': _empty_list,
+    'p_stmt_simple': _action_stmt_simple,
+    'p_stmt_compound': _action_stmt_compound,
+
+    # -- Token Sequence --
+    'p_token_seq_single': _action_token_seq_single,
+    'p_token_seq_multi': _action_token_seq_multi,
+    'p_token_item_token': _action_token_item,
+    'p_token_item_enclosed': _action_token_item,
+    'p_enclosed_paren': _action_enclosed,
+    'p_enclosed_brack': _action_enclosed,
+    'p_enclosed_brace': _action_enclosed,
+    'p_inner': _action_inner,
+    'p_inner_empty': _action_inner_empty,
+    'p_inner_item_token': _action_inner_item,
+    'p_inner_item_newline': _action_inner_item,
+
+    # -- Token Catch-All --
+    'p_token': _action_token,
+}

--- a/src/utils/tests/test_parser.py
+++ b/src/utils/tests/test_parser.py
@@ -1,0 +1,654 @@
+"""Parser Utility Tests"""
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..parser import TiferetParser
+
+# *** helpers
+
+def tok(type, value=None, line=1):
+    '''Create a minimal token dict.'''
+    return {'type': type, 'value': value or type, 'line': line}
+
+# *** fixtures
+
+# ** fixture: parser
+@pytest.fixture
+def parser() -> TiferetParser:
+    '''
+    Create a fresh TiferetParser instance for each test.
+    '''
+
+    return TiferetParser()
+
+# ** fixture: minimal_import_tokens
+@pytest.fixture
+def minimal_import_tokens():
+    '''
+    Minimal valid token stream: one import group with a single import statement.
+    Represents:
+        # *** imports
+        # ** core
+        from typing import Any
+    '''
+
+    return [
+        tok('ARTIFACT_IMPORTS_START', '# *** imports'),
+        tok('NEWLINE', '\n'),
+        tok('ARTIFACT_IMPORT_GROUP', '# ** core'),
+        tok('NEWLINE', '\n'),
+        tok('PYTHON_KEYWORD', 'from'),
+        tok('IDENTIFIER', 'typing'),
+        tok('PYTHON_KEYWORD', 'import'),
+        tok('IDENTIFIER', 'Any'),
+        tok('NEWLINE', '\n'),
+    ]
+
+# ** fixture: minimal_event_tokens
+@pytest.fixture
+def minimal_event_tokens():
+    '''
+    Token stream for a minimal event class with one method member.
+    Represents:
+        # *** events
+        # ** event: sample
+        class Sample(DomainEvent):
+            # * method: execute
+            def execute(self):
+                return result
+    '''
+
+    return [
+        tok('ARTIFACT_START', '# *** events'),
+        tok('NEWLINE', '\n'),
+        tok('ARTIFACT_SECTION', '# ** event: sample'),
+        tok('NEWLINE', '\n'),
+        tok('CLASS', 'class'),
+        tok('IDENTIFIER', 'Sample'),
+        tok('LPAREN', '('),
+        tok('IDENTIFIER', 'DomainEvent'),
+        tok('RPAREN', ')'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        # Member: method
+        tok('ARTIFACT_MEMBER', '# * method: execute'),
+        tok('NEWLINE', '\n'),
+        tok('DEF', 'def'),
+        tok('IDENTIFIER', 'execute'),
+        tok('LPAREN', '('),
+        tok('SELF', 'self'),
+        tok('RPAREN', ')'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        # Body: single snippet with return stmt
+        tok('RETURN', 'return'),
+        tok('IDENTIFIER', 'result'),
+        tok('NEWLINE', '\n'),
+        tok('DEDENT', ''),
+        tok('DEDENT', ''),
+    ]
+
+# ** fixture: import_and_event_tokens
+@pytest.fixture
+def import_and_event_tokens(minimal_import_tokens, minimal_event_tokens):
+    '''
+    Token stream combining an import group and an event group (two groups).
+    '''
+
+    return minimal_import_tokens + minimal_event_tokens
+
+# ** fixture: attribute_member_tokens
+@pytest.fixture
+def attribute_member_tokens():
+    '''
+    Token stream for a class with an attribute member.
+    Represents:
+        # *** events
+        # ** event: sample
+        class Sample(DomainEvent):
+            # * attribute: service
+            service: ErrorService
+    '''
+
+    return [
+        tok('ARTIFACT_START', '# *** events'),
+        tok('NEWLINE', '\n'),
+        tok('ARTIFACT_SECTION', '# ** event: sample'),
+        tok('NEWLINE', '\n'),
+        tok('CLASS', 'class'),
+        tok('IDENTIFIER', 'Sample'),
+        tok('LPAREN', '('),
+        tok('IDENTIFIER', 'DomainEvent'),
+        tok('RPAREN', ')'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        # Member: attribute
+        tok('ARTIFACT_MEMBER', '# * attribute: service'),
+        tok('NEWLINE', '\n'),
+        tok('IDENTIFIER', 'service'),
+        tok('COLON', ':'),
+        tok('IDENTIFIER', 'ErrorService'),
+        tok('NEWLINE', '\n'),
+        tok('DEDENT', ''),
+    ]
+
+# ** fixture: annotated_section_tokens
+@pytest.fixture
+def annotated_section_tokens():
+    '''
+    Token stream for an OBSOLETE-annotated section with a class.
+    Represents:
+        # *** events
+        # -- obsolete: replaced
+        # ** event: old_event
+        class OldEvent(DomainEvent):
+            # * method: execute
+            def execute(self):
+                return None
+    '''
+
+    return [
+        tok('ARTIFACT_START', '# *** events'),
+        tok('NEWLINE', '\n'),
+        tok('OBSOLETE', '# -- obsolete: replaced'),
+        tok('NEWLINE', '\n'),
+        tok('ARTIFACT_SECTION', '# ** event: old_event'),
+        tok('NEWLINE', '\n'),
+        tok('CLASS', 'class'),
+        tok('IDENTIFIER', 'OldEvent'),
+        tok('LPAREN', '('),
+        tok('IDENTIFIER', 'DomainEvent'),
+        tok('RPAREN', ')'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        tok('ARTIFACT_MEMBER', '# * method: execute'),
+        tok('NEWLINE', '\n'),
+        tok('DEF', 'def'),
+        tok('IDENTIFIER', 'execute'),
+        tok('LPAREN', '('),
+        tok('SELF', 'self'),
+        tok('RPAREN', ')'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        tok('RETURN', 'return'),
+        tok('PYTHON_KEYWORD', 'None'),
+        tok('NEWLINE', '\n'),
+        tok('DEDENT', ''),
+        tok('DEDENT', ''),
+    ]
+
+# ** fixture: decorated_method_tokens
+@pytest.fixture
+def decorated_method_tokens():
+    '''
+    Token stream for a class with a decorated method and return annotation.
+    Represents:
+        # *** events
+        # ** event: sample
+        class Sample(DomainEvent):
+            # * method: execute
+            @DomainEvent.parameters_required
+            def execute(self, id: str) -> None:
+                return result
+    '''
+
+    return [
+        tok('ARTIFACT_START', '# *** events'),
+        tok('NEWLINE', '\n'),
+        tok('ARTIFACT_SECTION', '# ** event: sample'),
+        tok('NEWLINE', '\n'),
+        tok('CLASS', 'class'),
+        tok('IDENTIFIER', 'Sample'),
+        tok('LPAREN', '('),
+        tok('IDENTIFIER', 'DomainEvent'),
+        tok('RPAREN', ')'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        tok('ARTIFACT_MEMBER', '# * method: execute'),
+        tok('NEWLINE', '\n'),
+        # Decorator
+        tok('AT', '@'),
+        tok('IDENTIFIER', 'DomainEvent'),
+        tok('DOT', '.'),
+        tok('IDENTIFIER', 'parameters_required'),
+        tok('NEWLINE', '\n'),
+        # Method def with params and return annotation
+        tok('DEF', 'def'),
+        tok('IDENTIFIER', 'execute'),
+        tok('LPAREN', '('),
+        tok('SELF', 'self'),
+        tok('COMMA', ','),
+        tok('IDENTIFIER', 'id'),
+        tok('COLON', ':'),
+        tok('IDENTIFIER', 'str'),
+        tok('RPAREN', ')'),
+        tok('ARROW', '->'),
+        tok('PYTHON_KEYWORD', 'None'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        tok('RETURN', 'return'),
+        tok('IDENTIFIER', 'result'),
+        tok('NEWLINE', '\n'),
+        tok('DEDENT', ''),
+        tok('DEDENT', ''),
+    ]
+
+# ** fixture: init_method_tokens
+@pytest.fixture
+def init_method_tokens():
+    '''
+    Token stream for a class with an __init__ method.
+    Represents:
+        # *** events
+        # ** event: sample
+        class Sample(DomainEvent):
+            # * init
+            def __init__(self, svc: Service):
+                self.svc = svc
+    '''
+
+    return [
+        tok('ARTIFACT_START', '# *** events'),
+        tok('NEWLINE', '\n'),
+        tok('ARTIFACT_SECTION', '# ** event: sample'),
+        tok('NEWLINE', '\n'),
+        tok('CLASS', 'class'),
+        tok('IDENTIFIER', 'Sample'),
+        tok('LPAREN', '('),
+        tok('IDENTIFIER', 'DomainEvent'),
+        tok('RPAREN', ')'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        tok('ARTIFACT_MEMBER', '# * init'),
+        tok('NEWLINE', '\n'),
+        tok('DEF', 'def'),
+        tok('INIT', '__init__'),
+        tok('LPAREN', '('),
+        tok('SELF', 'self'),
+        tok('COMMA', ','),
+        tok('IDENTIFIER', 'svc'),
+        tok('COLON', ':'),
+        tok('IDENTIFIER', 'Service'),
+        tok('RPAREN', ')'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        tok('SELF', 'self'),
+        tok('DOT', '.'),
+        tok('IDENTIFIER', 'svc'),
+        tok('EQUALS', '='),
+        tok('IDENTIFIER', 'svc'),
+        tok('NEWLINE', '\n'),
+        tok('DEDENT', ''),
+        tok('DEDENT', ''),
+    ]
+
+# ** fixture: docstring_class_tokens
+@pytest.fixture
+def docstring_class_tokens():
+    '''
+    Token stream for a class with a docstring and method with docstring.
+    Represents:
+        # *** events
+        # ** event: sample
+        class Sample(DomainEvent):
+            \"\"\"Sample event.\"\"\"
+            # * method: execute
+            def execute(self):
+                \"\"\"Run the event.\"\"\"
+                return True
+    '''
+
+    return [
+        tok('ARTIFACT_START', '# *** events'),
+        tok('NEWLINE', '\n'),
+        tok('ARTIFACT_SECTION', '# ** event: sample'),
+        tok('NEWLINE', '\n'),
+        tok('CLASS', 'class'),
+        tok('IDENTIFIER', 'Sample'),
+        tok('LPAREN', '('),
+        tok('IDENTIFIER', 'DomainEvent'),
+        tok('RPAREN', ')'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        tok('DOCSTRING', '"""Sample event."""'),
+        tok('NEWLINE', '\n'),
+        tok('ARTIFACT_MEMBER', '# * method: execute'),
+        tok('NEWLINE', '\n'),
+        tok('DEF', 'def'),
+        tok('IDENTIFIER', 'execute'),
+        tok('LPAREN', '('),
+        tok('SELF', 'self'),
+        tok('RPAREN', ')'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        tok('DOCSTRING', '"""Run the event."""'),
+        tok('NEWLINE', '\n'),
+        tok('RETURN', 'return'),
+        tok('PYTHON_KEYWORD', 'True'),
+        tok('NEWLINE', '\n'),
+        tok('DEDENT', ''),
+        tok('DEDENT', ''),
+    ]
+
+# ** fixture: snippet_with_comment_tokens
+@pytest.fixture
+def snippet_with_comment_tokens():
+    '''
+    Token stream for a method body with a line-comment-headed snippet.
+    Represents:
+        # *** events
+        # ** event: sample
+        class Sample(DomainEvent):
+            # * method: execute
+            def execute(self):
+                # Do the work.
+                result = compute()
+                return result
+    '''
+
+    return [
+        tok('ARTIFACT_START', '# *** events'),
+        tok('NEWLINE', '\n'),
+        tok('ARTIFACT_SECTION', '# ** event: sample'),
+        tok('NEWLINE', '\n'),
+        tok('CLASS', 'class'),
+        tok('IDENTIFIER', 'Sample'),
+        tok('LPAREN', '('),
+        tok('IDENTIFIER', 'DomainEvent'),
+        tok('RPAREN', ')'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        tok('ARTIFACT_MEMBER', '# * method: execute'),
+        tok('NEWLINE', '\n'),
+        tok('DEF', 'def'),
+        tok('IDENTIFIER', 'execute'),
+        tok('LPAREN', '('),
+        tok('SELF', 'self'),
+        tok('RPAREN', ')'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        # Snippet with comment header
+        tok('LINE_COMMENT', '# Do the work.'),
+        tok('NEWLINE', '\n'),
+        tok('IDENTIFIER', 'result'),
+        tok('EQUALS', '='),
+        tok('IDENTIFIER', 'compute'),
+        tok('LPAREN', '('),
+        tok('RPAREN', ')'),
+        tok('NEWLINE', '\n'),
+        # Return statement (separate snippet, no comment)
+        tok('RETURN', 'return'),
+        tok('IDENTIFIER', 'result'),
+        tok('NEWLINE', '\n'),
+        tok('DEDENT', ''),
+        tok('DEDENT', ''),
+    ]
+
+# *** tests
+
+# ** test: instantiation
+def test_instantiation(parser: TiferetParser) -> None:
+    '''
+    Test that TiferetParser can be instantiated without errors.
+    '''
+
+    assert parser is not None
+    assert parser.parser is not None
+
+
+# ** test: implements_parser_service
+def test_implements_parser_service(parser: TiferetParser) -> None:
+    '''
+    Test that TiferetParser is an instance of ParserService.
+    '''
+
+    from ...interfaces import ParserService
+    assert isinstance(parser, ParserService)
+
+
+# ** test: parse_minimal_imports
+def test_parse_minimal_imports(parser: TiferetParser, minimal_import_tokens) -> None:
+    '''
+    Test parsing a minimal import group returns a Module with one group.
+    '''
+
+    ast = parser.parse(minimal_import_tokens)
+    assert ast['type'] == 'Module'
+    assert len(ast['groups']) == 1
+    assert ast['groups'][0]['type'] == 'Group'
+    assert ast['groups'][0]['header'] == '# *** imports'
+
+
+# ** test: parse_import_section_body
+def test_parse_import_section_body(parser: TiferetParser, minimal_import_tokens) -> None:
+    '''
+    Test that import sections produce an ImportBlock with ImportStmt nodes.
+    '''
+
+    ast = parser.parse(minimal_import_tokens)
+    group = ast['groups'][0]
+    assert len(group['sections']) == 1
+    section = group['sections'][0]
+    assert section['type'] == 'Section'
+    assert section['header'] == '# ** core'
+    assert section['body']['type'] == 'ImportBlock'
+    assert len(section['body']['statements']) == 1
+    assert section['body']['statements'][0]['type'] == 'ImportStmt'
+    assert section['body']['statements'][0]['keyword'] == 'from'
+
+
+# ** test: parse_minimal_event
+def test_parse_minimal_event(parser: TiferetParser, minimal_event_tokens) -> None:
+    '''
+    Test parsing a minimal event class produces correct AST structure.
+    '''
+
+    ast = parser.parse(minimal_event_tokens)
+    assert ast['type'] == 'Module'
+    assert len(ast['groups']) == 1
+    group = ast['groups'][0]
+    assert group['header'] == '# *** events'
+    assert len(group['sections']) == 1
+    section = group['sections'][0]
+    assert section['body']['type'] == 'ClassDef'
+    assert section['body']['name'] == 'Sample'
+    assert section['body']['bases'] == ['DomainEvent']
+
+
+# ** test: parse_two_groups
+def test_parse_two_groups(parser: TiferetParser, import_and_event_tokens) -> None:
+    '''
+    Test parsing a token stream with two groups (imports + events).
+    '''
+
+    ast = parser.parse(import_and_event_tokens)
+    assert ast['type'] == 'Module'
+    assert len(ast['groups']) == 2
+    assert ast['groups'][0]['header'] == '# *** imports'
+    assert ast['groups'][1]['header'] == '# *** events'
+
+
+# ** test: parse_attribute_member
+def test_parse_attribute_member(parser: TiferetParser, attribute_member_tokens) -> None:
+    '''
+    Test parsing a class with an attribute member produces AttrDecl.
+    '''
+
+    ast = parser.parse(attribute_member_tokens)
+    class_def = ast['groups'][0]['sections'][0]['body']
+    assert len(class_def['members']) == 1
+    member = class_def['members'][0]
+    assert member['type'] == 'Member'
+    assert member['kind'] == 'attribute'
+    assert member['body']['type'] == 'AttrDecl'
+    assert member['body']['name'] == 'service'
+
+
+# ** test: parse_annotated_section
+def test_parse_annotated_section(parser: TiferetParser, annotated_section_tokens) -> None:
+    '''
+    Test parsing an OBSOLETE-annotated section.
+    '''
+
+    ast = parser.parse(annotated_section_tokens)
+    section = ast['groups'][0]['sections'][0]
+    assert len(section['annotations']) == 1
+    assert section['annotations'][0]['type'] == 'Annot'
+    assert section['annotations'][0]['kind'] == 'OBSOLETE'
+
+
+# ** test: parse_decorated_method
+def test_parse_decorated_method(parser: TiferetParser, decorated_method_tokens) -> None:
+    '''
+    Test parsing a decorated method with parameters and return annotation.
+    '''
+
+    ast = parser.parse(decorated_method_tokens)
+    class_def = ast['groups'][0]['sections'][0]['body']
+    member = class_def['members'][0]
+    method = member['body']
+    assert method['type'] == 'MethodDef'
+    assert method['name'] == 'execute'
+    assert method['decorator'] is not None
+    assert method['decorator']['type'] == 'Decorator'
+    assert method['return_type'] is not None
+    assert len(method['params']) > 0
+
+
+# ** test: parse_init_method
+def test_parse_init_method(parser: TiferetParser, init_method_tokens) -> None:
+    '''
+    Test parsing a class with __init__ produces a Member with kind "init".
+    '''
+
+    ast = parser.parse(init_method_tokens)
+    class_def = ast['groups'][0]['sections'][0]['body']
+    member = class_def['members'][0]
+    assert member['kind'] == 'init'
+    assert member['body']['type'] == 'MethodDef'
+    assert member['body']['name'] == '__init__'
+
+
+# ** test: parse_class_docstring
+def test_parse_class_docstring(parser: TiferetParser, docstring_class_tokens) -> None:
+    '''
+    Test that class and method docstrings are captured in the AST.
+    '''
+
+    ast = parser.parse(docstring_class_tokens)
+    class_def = ast['groups'][0]['sections'][0]['body']
+    assert class_def['docstring'] == '"""Sample event."""'
+    method = class_def['members'][0]['body']
+    assert method['docstring'] == '"""Run the event."""'
+
+
+# ** test: parse_snippet_with_comment
+def test_parse_snippet_with_comment(parser: TiferetParser, snippet_with_comment_tokens) -> None:
+    '''
+    Test that a comment-headed snippet collects all following statements.
+    The left-recursive stmt_list consumes all statements after the LINE_COMMENT
+    into a single snippet.
+    '''
+
+    ast = parser.parse(snippet_with_comment_tokens)
+    class_def = ast['groups'][0]['sections'][0]['body']
+    method = class_def['members'][0]['body']
+    assert len(method['body']) >= 1
+    commented_snippet = method['body'][0]
+    assert commented_snippet['type'] == 'Snippet'
+    assert commented_snippet['comment'] == '# Do the work.'
+    # Both statements are consumed into this snippet's stmt_list
+    assert len(commented_snippet['statements']) == 2
+
+
+# ** test: parse_error_unexpected_token
+def test_parse_error_unexpected_token(parser: TiferetParser) -> None:
+    '''
+    Test that an unexpected token raises SyntaxError with hierarchy terminology.
+    '''
+
+    # DEF directly under a group with no section header.
+    bad_tokens = [
+        tok('ARTIFACT_START', '# *** events'),
+        tok('NEWLINE', '\n'),
+        tok('DEF', 'def'),
+    ]
+    with pytest.raises(SyntaxError, match=r'Tiferet artifact hierarchy'):
+        parser.parse(bad_tokens)
+
+
+# ** test: parse_error_unexpected_eof
+def test_parse_error_unexpected_eof(parser: TiferetParser) -> None:
+    '''
+    Test that unexpected end-of-input raises SyntaxError with hierarchy terminology.
+    '''
+
+    # Incomplete: group header with no newline or sections.
+    bad_tokens = [
+        tok('ARTIFACT_START', '# *** events'),
+    ]
+    with pytest.raises(SyntaxError, match=r'Tiferet Domain Event structure'):
+        parser.parse(bad_tokens)
+
+
+# ** test: parse_error_class_no_section
+def test_parse_error_class_no_section(parser: TiferetParser) -> None:
+    '''
+    Test that a CLASS directly under a group (missing section header) raises SyntaxError.
+    '''
+
+    bad_tokens = [
+        tok('ARTIFACT_START', '# *** events'),
+        tok('NEWLINE', '\n'),
+        tok('CLASS', 'class'),
+        tok('IDENTIFIER', 'Foo'),
+    ]
+    with pytest.raises(SyntaxError):
+        parser.parse(bad_tokens)
+
+
+# ** test: parse_error_bare_attribute
+def test_parse_error_bare_attribute(parser: TiferetParser) -> None:
+    '''
+    Test that a bare attribute inside a class (no member header) raises SyntaxError.
+    '''
+
+    bad_tokens = [
+        tok('ARTIFACT_START', '# *** events'),
+        tok('NEWLINE', '\n'),
+        tok('ARTIFACT_SECTION', '# ** event: sample'),
+        tok('NEWLINE', '\n'),
+        tok('CLASS', 'class'),
+        tok('IDENTIFIER', 'Sample'),
+        tok('LPAREN', '('),
+        tok('IDENTIFIER', 'DomainEvent'),
+        tok('RPAREN', ')'),
+        tok('COLON', ':'),
+        tok('NEWLINE', '\n'),
+        tok('INDENT', ''),
+        # No ARTIFACT_MEMBER before the attribute
+        tok('IDENTIFIER', 'service'),
+        tok('COLON', ':'),
+        tok('IDENTIFIER', 'ErrorService'),
+        tok('NEWLINE', '\n'),
+        tok('DEDENT', ''),
+    ]
+    with pytest.raises(SyntaxError):
+        parser.parse(bad_tokens)


### PR DESCRIPTION
## Summary

Implements the `TiferetParser` utility (`src/utils/parser.py`) as the syntactic parser host class, following the exact dynamic-loading and Service-contract pattern established by `TiferetLexer` / `LexerService`.

## Changes

### New Files
- **`src/interfaces/parser.py`** — `ParserService` abstract interface with `parse(tokens) -> Dict` method
- **`src/utils/parser.py`** — `TiferetParser` implementing `ParserService`:
  - Dynamic grammar rule loading from `a.parser.RULES` via `MethodType` (mirrors lexer pattern)
  - PLY `yacc` initialization with `start='module'`, `debug=False`, `write_tables=False`
  - `TokenStream` adapter feeding `List[Dict]` token streams to PLY
  - `PLYToken` minimal PLY-compatible token object
  - `p_error` handler with Tiferet artifact hierarchy terminology
  - Full semantic action dispatch table mapping all 69 grammar rules to AST builder helpers
- **`src/utils/tests/test_parser.py`** — 16 unit tests covering:
  - Instantiation and `ParserService` contract
  - Minimal imports, events, two-group, attribute members
  - Annotated sections (OBSOLETE), decorated methods, `__init__` methods
  - Class and method docstrings, comment-headed snippets
  - 4 error cases (unexpected token, unexpected EOF, class without section, bare attribute)

### Modified Files
- **`src/assets/parser.py`** — Added `COLON`/`ARROW` precedence levels to resolve shift-reduce conflict between `token_seq` extension and `ret_annot` reduction when COLON follows a return type annotation
- **`src/interfaces/__init__.py`** — Export `ParserService`
- **`src/utils/__init__.py`** — Export `TiferetParser`

## Test Results

All 112 tests pass (96 existing + 16 new parser tests).

Closes #35

---
[Warp conversation](https://app.warp.dev/conversation/1b3e8b56-11e2-47be-8445-d812d8024415)

Co-Authored-By: Oz <oz-agent@warp.dev>