### PR TITLE
Events – Add Dedicated Parser Domain Events (#36)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,12 +8,24 @@ attrs:
   perform_lexical_analysis_event:
     module_path: src.events.scan
     class_name: PerformLexicalAnalysis
+  parser_initialized_event:
+    module_path: src.events.parser
+    class_name: ParserInitialized
+  perform_syntactic_analysis_event:
+    module_path: src.events.parser
+    class_name: PerformSyntacticAnalysis
+  syntactic_analysis_completed_event:
+    module_path: src.events.parser
+    class_name: SyntacticAnalysisCompleted
   emit_scan_result_event:
     module_path: src.events.scan
     class_name: EmitScanResult
   lexer_service:
     module_path: src.utils.lexer
     class_name: TiferetLexer
+  parser_service:
+    module_path: src.utils.parser
+    class_name: TiferetParser
 
 features:
   scan:
@@ -30,6 +42,16 @@ features:
         - attribute_id: perform_lexical_analysis_event
           name: Tokenize and compute lexical metrics
           data_key: analysis_result
+        - attribute_id: parser_initialized_event
+          name: Verify parser service readiness
+        - attribute_id: perform_syntactic_analysis_event
+          name: Parse token stream into AST
+          data_key: ast
+          params:
+            tokens: analysis_result.tokens
+        - attribute_id: syntactic_analysis_completed_event
+          name: Finalize syntactic analysis result
+          data_key: syntactic_result
         - attribute_id: emit_scan_result_event
           name: Format and emit scan result
 
@@ -49,6 +71,21 @@ errors:
     message:
       - lang: en_US
         text: 'Lexical error detected during tokenization'
+  parser_not_initialized:
+    name: Parser Not Initialized
+    message:
+      - lang: en_US
+        text: 'TiferetParser service failed to initialize'
+  invalid_ast_structure:
+    name: Invalid AST Structure
+    message:
+      - lang: en_US
+        text: 'Syntactic parser did not return a valid Module AST'
+  missing_ast:
+    name: Missing AST
+    message:
+      - lang: en_US
+        text: 'No AST received from syntactic analysis'
 
 logging: {}
 

--- a/src/events/__init__.py
+++ b/src/events/__init__.py
@@ -5,3 +5,4 @@
 # ** app
 from .settings import DomainEvent, TiferetError, a
 from .scan import ExtractText, LexerInitialized, PerformLexicalAnalysis, EmitScanResult
+from .parser import ParserInitialized, PerformSyntacticAnalysis, SyntacticAnalysisCompleted

--- a/src/events/parser.py
+++ b/src/events/parser.py
@@ -1,0 +1,148 @@
+"""Parser Domain Events"""
+
+# *** imports
+
+# ** core
+from typing import List, Dict, Any
+
+# ** app
+from .settings import DomainEvent, a
+from ..interfaces import ParserService
+
+# *** events
+
+# ** event: parser_initialized
+class ParserInitialized(DomainEvent):
+    '''
+    Validation gate event that verifies the TiferetParser service
+    is properly instantiated before syntactic analysis.
+    '''
+
+    # * attribute: parser
+    parser: ParserService
+
+    # * init
+    def __init__(self, parser: ParserService):
+        '''
+        Initialize with injected parser service.
+
+        :param parser: The parser service for syntactic analysis.
+        :type parser: ParserService
+        '''
+
+        # Set the parser service dependency.
+        self.parser = parser
+
+    # * method: execute
+    @DomainEvent.parameters_required([])
+    def execute(self, **kwargs) -> ParserService:
+        '''
+        Verify parser service readiness.
+
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The validated parser service.
+        :rtype: ParserService
+        '''
+
+        # Verify the parser service is not None.
+        self.verify(
+            expression=self.parser is not None,
+            error_code='PARSER_NOT_INITIALIZED',
+            message='TiferetParser service failed to initialize',
+        )
+
+        # Return the validated parser service.
+        return self.parser
+
+
+# ** event: perform_syntactic_analysis
+class PerformSyntacticAnalysis(DomainEvent):
+    '''
+    Core analytical event that performs syntactic parsing on the
+    tokenized input using the injected ParserService.
+    '''
+
+    # * attribute: parser
+    parser: ParserService
+
+    # * init
+    def __init__(self, parser: ParserService):
+        '''
+        Initialize with injected parser service.
+
+        :param parser: The parser service for syntactic analysis.
+        :type parser: ParserService
+        '''
+
+        # Set the parser service dependency.
+        self.parser = parser
+
+    # * method: execute
+    @DomainEvent.parameters_required(['tokens'])
+    def execute(self,
+            tokens: List[Dict[str, Any]],
+            **kwargs,
+        ) -> Dict[str, Any]:
+        '''
+        Parse token stream and produce structured AST.
+
+        :param tokens: Token stream from PerformLexicalAnalysis (post-IndentInjector).
+        :type tokens: List[Dict[str, Any]]
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: AST dict with Module root.
+        :rtype: Dict[str, Any]
+        '''
+
+        # Execute syntactic parsing via the injected parser service.
+        ast = self.parser.parse(tokens)
+
+        # Validate the AST root structure is a Module.
+        self.verify(
+            expression=isinstance(ast, dict) and ast.get('type') == 'Module',
+            error_code='INVALID_AST_STRUCTURE',
+            message='Syntactic parser did not return a valid Module AST',
+            ast_type=str(type(ast)),
+        )
+
+        # Return the AST for downstream events.
+        return ast
+
+
+# ** event: syntactic_analysis_completed
+class SyntacticAnalysisCompleted(DomainEvent):
+    '''
+    Terminal parser event that finalizes the AST and prepares it
+    for result emission.
+    '''
+
+    # * method: execute
+    def execute(self,
+            ast: Dict[str, Any] = None,
+            **kwargs,
+        ) -> Dict[str, Any]:
+        '''
+        Finalize syntactic analysis result.
+
+        :param ast: AST produced by PerformSyntacticAnalysis.
+        :type ast: Dict[str, Any]
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: Enriched result payload.
+        :rtype: Dict[str, Any]
+        '''
+
+        # Ensure a valid AST was received.
+        self.verify(
+            expression=ast is not None,
+            error_code='MISSING_AST',
+            message='No AST received from syntactic analysis',
+        )
+
+        # Return enriched payload.
+        return {
+            'event_type': 'SyntacticAnalysisCompleted',
+            'ast': ast,
+            'group_count': len(ast.get('groups', [])),
+        }

--- a/src/events/tests/test_parser.py
+++ b/src/events/tests/test_parser.py
@@ -1,0 +1,280 @@
+"""Parser Domain Event Tests"""
+
+# *** imports
+
+# ** core
+from unittest import mock
+
+# ** infra
+import pytest
+from tiferet.events import TiferetError
+
+# ** app
+from ..settings import DomainEvent
+from ..parser import ParserInitialized, PerformSyntacticAnalysis, SyntacticAnalysisCompleted
+from ...interfaces import ParserService
+
+# *** fixtures
+
+# ** fixture: mock_parser_service
+@pytest.fixture
+def mock_parser_service() -> ParserService:
+    '''
+    Create a mock ParserService for testing.
+
+    :return: A mock parser service.
+    :rtype: ParserService
+    '''
+
+    return mock.Mock(spec=ParserService)
+
+# ** fixture: sample_tokens
+@pytest.fixture
+def sample_tokens() -> list:
+    '''
+    Return sample token list as produced by PerformLexicalAnalysis.
+
+    :return: List of token dicts.
+    :rtype: list
+    '''
+
+    return [
+        {'type': 'ARTIFACT_START', 'value': '# *** events', 'line': 1, 'column': 0},
+        {'type': 'NEWLINE', 'value': '\n', 'line': 1, 'column': 13},
+        {'type': 'ARTIFACT_SECTION', 'value': '# ** event: sample_event', 'line': 3, 'column': 0},
+        {'type': 'NEWLINE', 'value': '\n', 'line': 3, 'column': 24},
+        {'type': 'CLASS', 'value': 'class', 'line': 4, 'column': 0},
+        {'type': 'IDENTIFIER', 'value': 'SampleEvent', 'line': 4, 'column': 6},
+    ]
+
+# ** fixture: sample_ast
+@pytest.fixture
+def sample_ast() -> dict:
+    '''
+    Return a sample Module AST as produced by TiferetParser.
+
+    :return: A Module AST dict.
+    :rtype: dict
+    '''
+
+    return {
+        'type': 'Module',
+        'groups': [
+            {
+                'type': 'Group',
+                'header': '# *** events',
+                'sections': [
+                    {
+                        'type': 'Section',
+                        'header': '# ** event: sample_event',
+                        'annotations': [],
+                        'body': {
+                            'type': 'ClassDef',
+                            'name': 'SampleEvent',
+                            'bases': ['DomainEvent'],
+                            'docstring': None,
+                            'members': [],
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+
+# *** tests — ParserInitialized
+
+# ** test: parser_initialized_success
+def test_parser_initialized_success(mock_parser_service: ParserService) -> None:
+    '''
+    Test successful validation of the parser service.
+
+    :param mock_parser_service: Mocked parser service.
+    :type mock_parser_service: ParserService
+    '''
+
+    # Execute the ParserInitialized event.
+    result = DomainEvent.handle(
+        ParserInitialized,
+        dependencies={'parser': mock_parser_service},
+    )
+
+    # Assert the parser service is returned.
+    assert result is mock_parser_service
+
+
+# ** test: parser_initialized_none_service
+def test_parser_initialized_none_service() -> None:
+    '''
+    Test that a None parser service raises TiferetError.
+    '''
+
+    # Attempt with None parser.
+    with pytest.raises(TiferetError):
+        DomainEvent.handle(
+            ParserInitialized,
+            dependencies={'parser': None},
+        )
+
+# *** tests — PerformSyntacticAnalysis
+
+# ** test: perform_syntactic_analysis_success
+def test_perform_syntactic_analysis_success(
+        mock_parser_service: ParserService,
+        sample_tokens: list,
+        sample_ast: dict,
+    ) -> None:
+    '''
+    Test successful syntactic parsing of tokens into AST.
+
+    :param mock_parser_service: Mocked parser service.
+    :type mock_parser_service: ParserService
+    :param sample_tokens: Sample token list.
+    :type sample_tokens: list
+    :param sample_ast: Expected AST result.
+    :type sample_ast: dict
+    '''
+
+    # Arrange the parser service to return the sample AST.
+    mock_parser_service.parse.return_value = sample_ast
+
+    # Execute via DomainEvent.handle with injected dependency.
+    result = DomainEvent.handle(
+        PerformSyntacticAnalysis,
+        dependencies={'parser': mock_parser_service},
+        tokens=sample_tokens,
+    )
+
+    # Assert the AST structure is correct.
+    assert isinstance(result, dict)
+    assert result['type'] == 'Module'
+    assert len(result['groups']) == 1
+
+    # Verify the parser service was called with the tokens.
+    mock_parser_service.parse.assert_called_once_with(sample_tokens)
+
+
+# ** test: perform_syntactic_analysis_missing_tokens
+def test_perform_syntactic_analysis_missing_tokens(
+        mock_parser_service: ParserService,
+    ) -> None:
+    '''
+    Test that missing tokens parameter raises TiferetError.
+
+    :param mock_parser_service: Mocked parser service.
+    :type mock_parser_service: ParserService
+    '''
+
+    # Attempt without tokens.
+    with pytest.raises(TiferetError):
+        DomainEvent.handle(
+            PerformSyntacticAnalysis,
+            dependencies={'parser': mock_parser_service},
+        )
+
+
+# ** test: perform_syntactic_analysis_invalid_ast
+def test_perform_syntactic_analysis_invalid_ast(
+        mock_parser_service: ParserService,
+        sample_tokens: list,
+    ) -> None:
+    '''
+    Test that an invalid AST root raises TiferetError.
+
+    :param mock_parser_service: Mocked parser service.
+    :type mock_parser_service: ParserService
+    :param sample_tokens: Sample token list.
+    :type sample_tokens: list
+    '''
+
+    # Arrange the parser to return a non-Module dict.
+    mock_parser_service.parse.return_value = {'type': 'InvalidRoot'}
+
+    # Attempt parsing with an invalid AST result.
+    with pytest.raises(TiferetError):
+        DomainEvent.handle(
+            PerformSyntacticAnalysis,
+            dependencies={'parser': mock_parser_service},
+            tokens=sample_tokens,
+        )
+
+
+# ** test: perform_syntactic_analysis_none_ast
+def test_perform_syntactic_analysis_none_ast(
+        mock_parser_service: ParserService,
+        sample_tokens: list,
+    ) -> None:
+    '''
+    Test that a None AST result raises TiferetError.
+
+    :param mock_parser_service: Mocked parser service.
+    :type mock_parser_service: ParserService
+    :param sample_tokens: Sample token list.
+    :type sample_tokens: list
+    '''
+
+    # Arrange the parser to return None.
+    mock_parser_service.parse.return_value = None
+
+    # Attempt parsing with a None result.
+    with pytest.raises(TiferetError):
+        DomainEvent.handle(
+            PerformSyntacticAnalysis,
+            dependencies={'parser': mock_parser_service},
+            tokens=sample_tokens,
+        )
+
+# *** tests — SyntacticAnalysisCompleted
+
+# ** test: syntactic_analysis_completed_success
+def test_syntactic_analysis_completed_success(sample_ast: dict) -> None:
+    '''
+    Test successful finalization of syntactic analysis.
+
+    :param sample_ast: Sample Module AST.
+    :type sample_ast: dict
+    '''
+
+    # Execute the SyntacticAnalysisCompleted event.
+    result = DomainEvent.handle(
+        SyntacticAnalysisCompleted,
+        ast=sample_ast,
+    )
+
+    # Assert the enriched payload structure.
+    assert result['event_type'] == 'SyntacticAnalysisCompleted'
+    assert result['ast'] is sample_ast
+    assert result['group_count'] == 1
+
+
+# ** test: syntactic_analysis_completed_empty_groups
+def test_syntactic_analysis_completed_empty_groups() -> None:
+    '''
+    Test finalization with an AST that has no groups.
+    '''
+
+    # Create an AST with empty groups.
+    ast = {'type': 'Module', 'groups': []}
+
+    # Execute the event.
+    result = DomainEvent.handle(
+        SyntacticAnalysisCompleted,
+        ast=ast,
+    )
+
+    # Assert group_count is zero.
+    assert result['group_count'] == 0
+    assert result['ast'] is ast
+
+
+# ** test: syntactic_analysis_completed_missing_ast
+def test_syntactic_analysis_completed_missing_ast() -> None:
+    '''
+    Test that a missing AST raises TiferetError.
+    '''
+
+    # Attempt without ast parameter.
+    with pytest.raises(TiferetError):
+        DomainEvent.handle(
+            SyntacticAnalysisCompleted,
+            ast=None,
+        )


### PR DESCRIPTION
## Summary

Introduces a dedicated parser events module (`src/events/parser.py`) with three Domain Events for syntactic analysis, creating a clean bounded-context separation from the lexical scanning events in `scan.py`.

Closes #36

## Changes

### New Files
- **`src/events/parser.py`** — Three domain events following the Tiferet Domain Event pattern:
  - `ParserInitialized` — Validates the injected `ParserService` is ready
  - `PerformSyntacticAnalysis` — Parses token stream into a Module AST via injected service, verifies root structure
  - `SyntacticAnalysisCompleted` — Finalizes AST into enriched payload with `group_count`
- **`src/events/tests/test_parser.py`** — 9 unit tests covering success and error paths for all 3 events using `DomainEvent.handle`

### Modified Files
- **`src/events/__init__.py`** — Export the 3 new parser events
- **`config.yml`** — Register `parser_service` + 3 parser event attrs, chain them in `scan.event` pipeline (after `PerformLexicalAnalysis`, before `EmitScanResult`), add 3 error definitions (`parser_not_initialized`, `invalid_ast_structure`, `missing_ast`)

## Pipeline (Updated)
`ExtractText → LexerInitialized → PerformLexicalAnalysis → ParserInitialized → PerformSyntacticAnalysis → SyntacticAnalysisCompleted → EmitScanResult`

## Testing
All 26 tests pass (17 existing scan + 9 new parser).

---
[Warp Conversation](https://app.warp.dev/conversation/39ad33b4-41e8-4b3a-b07f-8bbe083b0277)

Co-Authored-By: Oz <oz-agent@warp.dev>