### PR TITLE
Parser – Wire Parse Pipeline and Implement EmitParseResult (#37)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -20,6 +20,9 @@ attrs:
   emit_scan_result_event:
     module_path: src.events.scan
     class_name: EmitScanResult
+  emit_parse_result_event:
+    module_path: src.events.parser
+    class_name: EmitParseResult
   lexer_service:
     module_path: src.utils.lexer
     class_name: TiferetLexer
@@ -54,6 +57,29 @@ features:
           data_key: syntactic_result
         - attribute_id: emit_scan_result_event
           name: Format and emit scan result
+  parse:
+    event:
+      name: 'Parse Event'
+      description: 'Perform syntactic parsing on a Tiferet event source file'
+      commands:
+        - attribute_id: extract_text_event
+          name: Extract text blocks from source file
+          data_key: text_blocks
+        - attribute_id: lexer_initialized_event
+          name: Validate extracted text blocks
+          data_key: validated_blocks
+        - attribute_id: perform_lexical_analysis_event
+          name: Tokenize and compute lexical metrics
+          data_key: analysis_result
+        - attribute_id: parser_initialized_event
+          name: Verify parser service readiness
+        - attribute_id: perform_syntactic_analysis_event
+          name: Parse token stream into AST
+          data_key: ast
+          params:
+            tokens: analysis_result.tokens
+        - attribute_id: emit_parse_result_event
+          name: Assemble and emit parse result
 
 errors:
   source_file_not_found:

--- a/src/events/__init__.py
+++ b/src/events/__init__.py
@@ -5,4 +5,4 @@
 # ** app
 from .settings import DomainEvent, TiferetError, a
 from .scan import ExtractText, LexerInitialized, PerformLexicalAnalysis, EmitScanResult
-from .parser import ParserInitialized, PerformSyntacticAnalysis, SyntacticAnalysisCompleted
+from .parser import ParserInitialized, PerformSyntacticAnalysis, SyntacticAnalysisCompleted, EmitParseResult

--- a/src/events/parser.py
+++ b/src/events/parser.py
@@ -3,11 +3,13 @@
 # *** imports
 
 # ** core
+from datetime import datetime, timezone
 from typing import List, Dict, Any
 
 # ** app
 from .settings import DomainEvent, a
 from ..interfaces import ParserService
+from ..utils import ScanOutputWriter
 
 # *** events
 
@@ -146,3 +148,85 @@ class SyntacticAnalysisCompleted(DomainEvent):
             'ast': ast,
             'group_count': len(ast.get('groups', [])),
         }
+
+
+# ** event: emit_parse_result
+class EmitParseResult(DomainEvent):
+    '''
+    Final event in the parse.event pipeline.
+    Assembles the result payload with syntactic AST and delegates to output writer.
+    '''
+
+    # * method: execute
+    @DomainEvent.parameters_required(['ast'])
+    def execute(self,
+            ast: Dict[str, Any],
+            source_file: str = None,
+            analysis_result: Dict[str, Any] = None,
+            extract: str = None,
+            summary_only: bool = False,
+            with_metrics: bool = False,
+            output_format: str = 'yaml',
+            output: str = None,
+            **kwargs,
+        ) -> Dict[str, Any]:
+        '''
+        Assemble and emit the parse result payload.
+
+        :param ast: The syntactic AST from PerformSyntacticAnalysis.
+        :type ast: Dict[str, Any]
+        :param source_file: Original source file path.
+        :type source_file: str
+        :param analysis_result: Output from PerformLexicalAnalysis.
+        :type analysis_result: Dict[str, Any]
+        :param extract: Original -x filter string.
+        :type extract: str
+        :param summary_only: If truthy, omit tokens and include metrics.
+        :type summary_only: bool
+        :param with_metrics: If truthy, include metrics alongside tokens.
+        :type with_metrics: bool
+        :param output_format: Output format: yaml, json, or auto.
+        :type output_format: str
+        :param output: File path to write output to.
+        :type output: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The assembled parse result payload.
+        :rtype: Dict[str, Any]
+        '''
+
+        # Default analysis if missing.
+        analysis = analysis_result or {
+            'tokens': [],
+            'token_count': 0,
+            'metrics': {},
+        }
+
+        # Build base payload with AST.
+        result = {
+            'event_type': 'ParseCompleted',
+            'timestamp': datetime.now(timezone.utc).isoformat(),
+            'source_file': source_file,
+            'token_count': analysis['token_count'],
+            'ast': ast,
+        }
+
+        # Include extracted artifact names if -x was used.
+        extracted_names = ScanOutputWriter.parse_extract_names(extract)
+        if extracted_names:
+            result['extracted_artifacts'] = extracted_names
+
+        # Include metrics if requested.
+        if with_metrics or summary_only:
+            result['metrics'] = analysis['metrics']
+
+        # Include tokens unless summary-only.
+        if not summary_only:
+            result['tokens'] = analysis['tokens']
+
+        # Write to file if output path specified.
+        if output:
+            ScanOutputWriter.write(result, output, output_format)
+
+        # Return the result payload.
+        return result


### PR DESCRIPTION
## Summary

Completes the dedicated `parse.event` pipeline by implementing `EmitParseResult` and wiring the full feature group in `config.yml`. Closes #37.

## Changes

- **`src/events/parser.py`** — Added `EmitParseResult` domain event that assembles the parse result payload (including syntactic AST) and delegates file output to `ScanOutputWriter`
- **`config.yml`** — Added `emit_parse_result_event` container attr and wired the complete `parse.event` feature group: `ExtractText → LexerInitialized → PerformLexicalAnalysis → ParserInitialized → PerformSyntacticAnalysis → EmitParseResult`
- **`src/events/__init__.py`** — Exported `EmitParseResult` from the events package

## Verification

- All 121 existing tests pass with no regressions
- `scan.event` pipeline is untouched
- `ScanOutputWriter` reused with no modifications

---
[Warp conversation](https://app.warp.dev/conversation/c9beb934-eb46-43ca-80ca-183e1a5b3c4d)

Co-Authored-By: Oz <oz-agent@warp.dev>