### PR TITLE
Documentation & Release – Update Project Docs and Bump Version to 0.3.0 (#38)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,41 @@
-# Tiferet Command Parser — Educational Scanner
+# Tiferet Command Parser — Educational Scanner & Parser
 
 **Repository:** tiferet-command-parser-edu
-**Version:** 0.2.0
-**Branch:** v0.2-release
+**Version:** 0.3.0
+**Branch:** v0.3-release
 **Framework:** Tiferet (DDD, Domain Events)
-**Purpose:** Educational compiler front-end for ECE 506 (Compiler Design) — performs lexical scanning on Python source files written in the Tiferet framework's Domain Event pattern.
+**Purpose:** Educational compiler front-end for ECE 506 (Compiler Design) — performs lexical scanning and syntactic parsing on Python source files written in the Tiferet framework's Domain Event pattern.
 
 ## Architecture
 
-This project is a Tiferet application. It uses Domain Events as the primary operational units, wired via YAML configuration (`config.yml`), and executed through the Tiferet CLI context. The scanner reads Tiferet-patterned Python source files, extracts artifact blocks (including imports), tokenizes them using a PLY-based lexer, injects synthetic layout tokens, computes domain metrics, and emits structured output (YAML/JSON).
+This project is a Tiferet application. It uses Domain Events as the primary operational units, wired via YAML configuration (`config.yml`), and executed through the Tiferet CLI context. The compiler reads Tiferet-patterned Python source files, extracts artifact blocks (including imports), tokenizes them using a PLY-based lexer, injects synthetic layout tokens, parses the token stream into a structured AST via a PLY yacc-based parser, computes domain metrics, and emits structured output (YAML/JSON).
+
+The compiler has two bounded contexts:
+- **Lexical scanning** (`src/events/scan.py`) — text extraction, tokenization, metrics, and scan result emission.
+- **Syntactic parsing** (`src/events/parser.py`) — parser initialization, AST construction, and parse result emission.
 
 ### Pipeline (Feature: `scan.event`)
+
+The `scan.event` pipeline chains lexical and syntactic events:
 
 1. **ExtractText** — Reads source file, extracts `# *** imports` block and `# ** event:` artifact blocks. Supports `-x` filtering; imports are always included.
 2. **LexerInitialized** — Validates that extracted text blocks are non-empty and ready for tokenization.
 3. **PerformLexicalAnalysis** — Tokenizes blocks via `LexerService`, injects `INDENT`/`DEDENT` tokens via `IndentInjector`, and computes domain metrics.
-4. **EmitScanResult** — Assembles the final payload with optional metrics, summary-only mode, extracted artifact names, and file output.
+4. **ParserInitialized** — Validates that the `ParserService` is properly instantiated.
+5. **PerformSyntacticAnalysis** — Parses the token stream into a structured AST via `ParserService`.
+6. **SyntacticAnalysisCompleted** — Finalizes the AST and enriches the result payload.
+7. **EmitScanResult** — Assembles the final payload with optional metrics, summary-only mode, extracted artifact names, and file output.
+
+### Pipeline (Feature: `parse.event`)
+
+The `parse.event` pipeline shares lexical steps but uses a dedicated parse result emitter:
+
+1. **ExtractText** — Same as `scan.event`.
+2. **LexerInitialized** — Same as `scan.event`.
+3. **PerformLexicalAnalysis** — Same as `scan.event`.
+4. **ParserInitialized** — Same as `scan.event`.
+5. **PerformSyntacticAnalysis** — Same as `scan.event`.
+6. **EmitParseResult** — Assembles the parse result payload with AST, optional metrics, and file output.
 
 ## Project Structure
 
@@ -26,6 +46,9 @@ pyproject.toml           — Project metadata, dependencies (tiferet, ply, pyyam
 docs/
   guides/
     lexical_spec.md      — Formal lexical specification for all 53 token types
+    grammar_spec.md      — Context-free grammar specification and LR(1)/LALR verification
+    utils/
+      parser.md          — Parser utility guide (TiferetParser, ParserService, AST structure)
 samples/
   empty_events.py                    — Empty placeholder events module (success case)
   add_error_event.py                 — Single AddError event with service injection (success case)
@@ -36,29 +59,35 @@ samples/
   invalid_annotation_event.py        — Malformed OBSOLETE/TODO annotations (failure case)
 
 src/
-  __init__.py            — Package exports and version (0.2.0)
+  __init__.py            — Package exports and version (0.3.0)
   assets/
     __init__.py          — Assets package exports
     lexer.py             — Token constants (53 types), rule handlers (functions/regexes), RULES mapping dict
+    parser.py            — Grammar constants (69 productions), precedence, RULES mapping, AST builders
   domain/
     __init__.py          — Reserved for future domain objects
   events/
     settings.py          — Re-exports DomainEvent, TiferetError; imports local assets as `a`
     scan.py              — Scanner domain events: ExtractText, LexerInitialized, PerformLexicalAnalysis, EmitScanResult
+    parser.py            — Parser domain events: ParserInitialized, PerformSyntacticAnalysis, SyntacticAnalysisCompleted, EmitParseResult
     __init__.py          — Events package exports
     tests/
       test_scan.py       — 17 tests for all scanner events (DomainEvent.handle pattern)
+      test_parser.py     — 9 tests for parser domain events
   interfaces/
     lexer.py             — LexerService abstract interface (extends tiferet Service)
+    parser.py            — ParserService abstract interface (extends tiferet Service)
     __init__.py          — Interfaces package exports
   utils/
     lexer.py             — TiferetLexer: generic PLY host that loads tokens and rules dynamically from assets
+    parser.py            — TiferetParser: PLY yacc-based parser with dynamic grammar loading from assets
     artifact.py          — ArtifactBlockParser: artifact block extraction, imports parsing, extract filtering
     output.py            — ScanOutputWriter: file output with YAML/JSON format auto-detection
     indent.py            — IndentInjector: post-tokenization INDENT/DEDENT injection for method bodies
     __init__.py          — Utils package exports
     tests/
       test_lexer.py      — 43 tests for all lexer token rules
+      test_parser.py     — 16 tests for parser grammar rules and AST structure
       test_artifact.py   — 13 tests for artifact block parser utility
       test_output.py     — 11 tests for scan output writer utility
       test_indent.py     — 12 tests for IndentInjector
@@ -67,12 +96,29 @@ src/
 ## Key Files
 
 ### `src/events/scan.py`
-All scanner domain events. Each event follows the Tiferet pattern: `@DomainEvent.parameters_required` for validation, `self.verify()` for domain rules, service injection via constructor. Parsing and output concerns are delegated to utility classes.
+Scanner domain events. Each event follows the Tiferet pattern: `@DomainEvent.parameters_required` for validation, `self.verify()` for domain rules, service injection via constructor. Parsing and output concerns are delegated to utility classes.
 
 - **ExtractText** — Reads source file, delegates artifact extraction to `ArtifactBlockParser`. The imports block (`__imports__`) is always included, even with `-x` extract filtering.
 - **LexerInitialized** — Validates block content is non-empty.
 - **PerformLexicalAnalysis** — Injects `LexerService`, tokenizes blocks, runs `IndentInjector.inject()` post-tokenization, computes metrics via `Counter`.
 - **EmitScanResult** — Builds output payload. Delegates file writing to `ScanOutputWriter`. Supports `--summary-only` and `--with-metrics` flags.
+
+### `src/events/parser.py`
+Parser domain events. Dedicated bounded context for syntactic analysis, separate from lexical scanning.
+
+- **ParserInitialized** — Validation gate: verifies `ParserService` is properly instantiated before parsing.
+- **PerformSyntacticAnalysis** — Core analytical event: parses token stream via injected `ParserService`, validates the resulting AST root is a Module.
+- **SyntacticAnalysisCompleted** — Terminal event: finalizes AST, enriches result with group count metadata.
+- **EmitParseResult** — Final event in `parse.event` pipeline: assembles result payload with AST, optional metrics, and delegates file output to `ScanOutputWriter`.
+
+### `src/utils/parser.py`
+PLY yacc-based syntactic parser (`TiferetParser`) implementing `ParserService`. Dynamically loads grammar rules from `src/assets/parser.py`, mirroring the `TiferetLexer` pattern. Includes `TokenStream` adapter (feeds `List[Dict]` to PLY), `PLYToken` wrapper, semantic action dispatch table (`_SEMANTIC_ACTIONS`), and AST-building helper functions.
+
+### `src/interfaces/parser.py`
+Abstract `ParserService(Service)` with single method `parse(tokens) -> Dict[str, Any]`.
+
+### `src/assets/parser.py`
+Grammar assets: `TOKENS` (re-exported from lexer), `precedence` tuple, 69 BNF production rules as string constants, `RULES` mapping dict, and AST builder helper functions (`build_module`, `build_group`, `build_section`, `build_class_def`, `build_member`, `build_method_def`, etc.).
 
 ### `src/utils/indent.py`
 Post-tokenization utility (`IndentInjector`) with a single static method:
@@ -107,16 +153,16 @@ Abstract `LexerService(Service)` with single method `tokenize(text) -> List[Dict
 
 ### `config.yml`
 Tiferet YAML configuration defining:
-- **attrs** — Container attributes mapping event classes and lexer service
-- **features** — `scan.event` pipeline with 4 chained commands
-- **errors** — Structured error definitions (SOURCE_FILE_NOT_FOUND, TEXT_EXTRACTION_FAILED, LEXICAL_ERROR_DETECTED)
+- **attrs** — Container attributes mapping event classes, lexer service, and parser service
+- **features** — `scan.event` pipeline (7 chained commands: lexical + syntactic + emit) and `parse.event` pipeline (6 chained commands: lexical + syntactic + parse emit)
+- **errors** — Structured error definitions (SOURCE_FILE_NOT_FOUND, TEXT_EXTRACTION_FAILED, LEXICAL_ERROR_DETECTED, PARSER_NOT_INITIALIZED, INVALID_AST_STRUCTURE, MISSING_AST)
 - **cli** — CLI command definition with args (source_file, -o, --format, -x, --summary-only, --with-metrics, --metrics-format)
 - **interfaces** — `compiler` (AppInterfaceContext) and `compiler_cli` (CliContext) configurations
 
 ## CLI Usage
 
 ```bash
-# Full scan (YAML output)
+# Full scan with lexical + syntactic analysis (YAML output)
 python compiler.py scan event <source_file> -o output.yaml
 
 # JSON output
@@ -132,14 +178,14 @@ python compiler.py scan event <source_file> -o output.yaml -x add_error,get_erro
 ## Testing
 
 ```bash
-python -m pytest src/ -v    # 96 tests (43 lexer + 13 artifact + 11 output + 12 indent + 17 events)
+python -m pytest src/ -v    # 121 tests (43 lexer + 16 parser util + 13 artifact + 11 output + 12 indent + 17 scanner events + 9 parser events)
 ```
 
-Tests use `DomainEvent.handle` for event invocation and mock `LexerService` for isolation. Utility tests validate parsing and output logic independently of domain events.
+Tests use `DomainEvent.handle` for event invocation and mock `LexerService`/`ParserService` for isolation. Utility tests validate lexing, parsing, and output logic independently of domain events.
 
 ## Dependencies
 
 - `tiferet>=1.9.5` — DDD framework (Domain Events, CLI context, DI container)
-- `ply>=3.11` — Lexer generator
+- `ply>=3.11` — Lexer and parser generator
 - `pyyaml>=6.0` — YAML output
 - `pytest>=7.0` — Testing (dev)

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 
-### Scanner Usage
+### Usage
 
-The scanner performs lexical analysis on Python source files written in the Tiferet Domain Event pattern, recognizing domain-specific tokens such as artifact comments, service calls, factory invocations, and structural keywords.
+The compiler performs lexical scanning and syntactic parsing on Python source files written in the Tiferet Domain Event pattern, recognizing domain-specific tokens such as artifact comments, service calls, factory invocations, and structural keywords, then building a structured AST reflecting the three-tier artifact hierarchy.
 
 #### CLI Commands
 
-Scan a Tiferet event source file:
+Scan a Tiferet event source file (lexical analysis + syntactic parsing):
 
 ```bash
 python compiler.py scan event <source_file>
@@ -59,7 +59,7 @@ python compiler.py scan event <source_file>
 **Examples:**
 
 ```bash
-# Full scan with YAML output
+# Full scan with YAML output (lexical + syntactic analysis)
 python compiler.py scan event samples/add_error_event.py -o results.yaml
 
 # JSON output
@@ -109,7 +109,7 @@ The `samples/` directory contains 7 Tiferet Domain Event source files for testin
 
 ### Running Tests
 
-The test suite validates every token type, non-matching/unknown tokens, and the full event pipeline.
+The test suite validates every token type, non-matching/unknown tokens, parser grammar rules, and the full event pipeline.
 
 ```bash
 # Run all tests
@@ -127,11 +127,17 @@ python -m pytest src/utils/tests/test_output.py -v
 # Run only indent injector tests (12 tests)
 python -m pytest src/utils/tests/test_indent.py -v
 
-# Run only event tests (17 tests)
+# Run only parser utility tests (16 tests)
+python -m pytest src/utils/tests/test_parser.py -v
+
+# Run only scanner event tests (17 tests)
 python -m pytest src/events/tests/test_scan.py -v
+
+# Run only parser event tests (9 tests)
+python -m pytest src/events/tests/test_parser.py -v
 ```
 
-**Total: 96 tests** (43 lexer + 13 artifact + 11 output + 12 indent + 17 events)
+**Total: 121 tests** (43 lexer + 13 artifact + 11 output + 12 indent + 16 parser util + 17 scanner events + 9 parser events)
 
 ### Project Structure
 
@@ -142,6 +148,9 @@ pyproject.toml           — Project metadata, dependencies (tiferet, ply, pyyam
 docs/
   guides/
     lexical_spec.md      — Formal lexical specification for all 53 token types
+    grammar_spec.md      — Context-free grammar specification and LR(1)/LALR verification
+    utils/
+      parser.md          — Parser utility guide (TiferetParser, ParserService, AST structure)
 samples/
   empty_events.py                    — Empty placeholder events module (success case)
   add_error_event.py                 — Single AddError event with service injection (success case)
@@ -152,29 +161,35 @@ samples/
   invalid_annotation_event.py        — Malformed OBSOLETE/TODO annotations (failure case)
 
 src/
-  __init__.py            — Package exports and version (0.2.0)
+  __init__.py            — Package exports and version (0.3.0)
   assets/
     __init__.py          — Assets package exports
     lexer.py             — Token constants (53 types), rule handlers, RULES mapping dict
+    parser.py            — Grammar constants (69 productions), precedence, RULES mapping, AST builders
   domain/
     __init__.py          — Reserved for future domain objects
   events/
     settings.py          — Re-exports DomainEvent, TiferetError; imports local assets as `a`
     scan.py              — Scanner domain events: ExtractText, LexerInitialized, PerformLexicalAnalysis, EmitScanResult
+    parser.py            — Parser domain events: ParserInitialized, PerformSyntacticAnalysis, SyntacticAnalysisCompleted, EmitParseResult
     __init__.py          — Events package exports
     tests/
       test_scan.py       — 17 tests for all scanner events (DomainEvent.handle pattern)
+      test_parser.py     — 9 tests for parser domain events
   interfaces/
     lexer.py             — LexerService abstract interface (extends tiferet Service)
+    parser.py            — ParserService abstract interface (extends tiferet Service)
     __init__.py          — Interfaces package exports
   utils/
     lexer.py             — TiferetLexer: generic PLY host that loads tokens and rules dynamically from assets
+    parser.py            — TiferetParser: PLY yacc-based parser with dynamic grammar loading from assets
     artifact.py          — ArtifactBlockParser: artifact block extraction, imports parsing, extract filtering
     output.py            — ScanOutputWriter: file output with YAML/JSON format auto-detection
     indent.py            — IndentInjector: post-tokenization INDENT/DEDENT injection for method bodies
     __init__.py          — Utils package exports
     tests/
       test_lexer.py      — 43 tests for all lexer token rules
+      test_parser.py     — 16 tests for parser grammar rules and AST structure
       test_artifact.py   — 13 tests for artifact block parser utility
       test_output.py     — 11 tests for scan output writer utility
       test_indent.py     — 12 tests for IndentInjector
@@ -184,13 +199,15 @@ src/
 - **[PROJECT_SUMMARY.md](./PROJECT_SUMMARY.md)** — ECE 506 course context and educational goals
 - **[PROJECT_PROPOSAL.md](./PROJECT_PROPOSAL.md)** — Completed ECE 506 initial project definition template
 - **[lexical_spec.md](./docs/guides/lexical_spec.md)** — Formal lexical specification for all token types
+- **[grammar_spec.md](./docs/guides/grammar_spec.md)** — Context-free grammar specification and LALR verification
+- **[parser.md](./docs/guides/utils/parser.md)** — Parser utility guide (TiferetParser, AST structure)
 - **[AGENTS.md](./AGENTS.md)** — AI agent codebase index
 
 ### Development Status
 
-- **Current branch**: `v0.2-release`
-- **Version**: 0.2.0
-- **Focus**: Lexical scanner for the Tiferet Domain Event pattern
+- **Current branch**: `v0.3-release`
+- **Version**: 0.3.0
+- **Focus**: Lexical scanner and syntactic parser for the Tiferet Domain Event pattern
 - **License**: MIT (educational reuse encouraged)
 
 ### Acknowledgments

--- a/docs/guides/utils/parser.md
+++ b/docs/guides/utils/parser.md
@@ -1,0 +1,231 @@
+# Parser Utility — TiferetParser
+
+## Overview
+
+`TiferetParser` is a PLY yacc-based syntactic parser for the Tiferet Domain Event dialect. It implements the `ParserService` interface and dynamically loads grammar rules from `src/assets/parser.py`, exactly mirroring the `TiferetLexer` pattern for lexical analysis.
+
+The parser consumes a token stream produced by `TiferetLexer` (with synthetic `INDENT`/`DEDENT` tokens injected by `IndentInjector`) and produces a structured AST reflecting the three-tier artifact comment hierarchy:
+
+- **Tier 1** — Module / Artifact Groups (`# ***`)
+- **Tier 2** — Artifact Sections (`# **`)
+- **Tier 3** — Artifact Members (`# *`)
+
+**Files:**
+- `src/utils/parser.py` — `TiferetParser` utility class, `TokenStream` adapter, `PLYToken`, semantic actions, and helpers
+- `src/interfaces/parser.py` — `ParserService` abstract interface
+- `src/assets/parser.py` — Grammar constants: `TOKENS`, `precedence`, `RULES` mapping, and AST builder helpers
+
+
+## ParserService Interface
+
+`ParserService` extends Tiferet's `Service` (ABC) and defines a single abstract method:
+
+```python
+class ParserService(Service):
+    @abstractmethod
+    def parse(self, tokens: List[Dict[str, Any]]) -> Dict[str, Any]:
+        '''Parse a list of tokens into a structured AST.'''
+        raise NotImplementedError()
+```
+
+`TiferetParser` is the concrete implementation. Domain events depend on the `ParserService` interface, keeping domain logic decoupled from the PLY infrastructure.
+
+
+## Dynamic Grammar Loading
+
+`TiferetParser.__init__` dynamically attaches grammar rules from `src/assets/parser.py` — the same pattern used by `TiferetLexer` for lexer rules:
+
+1. **Token list and precedence** are sourced directly from `a.parser.TOKENS` and `a.parser.precedence`.
+2. **Grammar rules** are loaded from `a.parser.RULES`, a dict mapping PLY rule function names (e.g., `p_module`, `p_group`) to either:
+   - **String BNF rules** — wrapped with a semantic action function resolved from the `_SEMANTIC_ACTIONS` dispatch table.
+   - **Callable rules** — bound directly as methods on the parser instance.
+3. PLY's `yacc.yacc()` builds the LALR parser with `module=self`, `start='module'`, `debug=False`, and `write_tables=False`.
+
+This design keeps grammar definitions (BNF productions + AST builders) in the assets layer, while `TiferetParser` serves as a generic PLY host.
+
+
+## Grammar Assets (`src/assets/parser.py`)
+
+The grammar assets module defines the complete context-free grammar for the Tiferet Domain Event dialect:
+
+- **`TOKENS`** — re-exported from `src/assets/lexer.py` (all 53 token types)
+- **`precedence`** — PLY precedence tuple resolving structural boundary ambiguities (`COLON`, `ARROW`, artifact markers, `DEDENT`)
+- **`RULES`** — dict of 69 production rules organized by tier:
+  - Tier 1: Module / Artifact Groups (rules 1–6)
+  - Tier 2: Artifact Sections (rules 7–16)
+  - Section Body / Imports (rules 17–22)
+  - Class Definition (rules 23–27)
+  - Tier 3: Artifact Members (rules 28–34)
+  - Method Definition (rules 35–43)
+  - Function Definition (rules 44–47)
+  - Body / Snippets (rules 48–57)
+  - Token Sequence (rules 58–68)
+  - Token Catch-All (rule 69)
+- **AST builder helpers** — `build_module`, `build_group`, `build_section`, `build_class_def`, `build_member`, `build_method_def`, `build_func_def`, `build_snippet`, `build_stmt`, `build_enclosed`, etc.
+
+See [grammar_spec.md](../grammar_spec.md) for the formal grammar definition, LR(1) automaton, and LALR verification.
+
+
+## Usage
+
+### Basic Usage
+
+```python
+from src.utils import TiferetLexer, TiferetParser
+from src.utils import ArtifactBlockParser, IndentInjector
+
+# 1. Read source file
+with open('samples/add_error_event.py', 'r') as f:
+    source = f.read()
+
+# 2. Extract artifact blocks (imports + events)
+blocks = ArtifactBlockParser.extract_artifact_blocks(source, 'event')
+imports = ArtifactBlockParser.extract_imports_block(source)
+
+# 3. Tokenize each block
+lexer = TiferetLexer()
+all_tokens = []
+for block in [imports] + blocks:
+    tokens = lexer.tokenize(block['text'])
+    tokens = IndentInjector.inject(tokens)
+    all_tokens.extend(tokens)
+
+# 4. Parse token stream into AST
+parser = TiferetParser()
+ast = parser.parse(all_tokens)
+```
+
+### Pipeline Integration
+
+In the Tiferet application, the parser is wired as part of the `parse.event` pipeline in `config.yml`:
+
+1. **ExtractText** — reads source file, extracts artifact blocks
+2. **LexerInitialized** — validates extracted text blocks
+3. **PerformLexicalAnalysis** — tokenizes blocks via `LexerService` + `IndentInjector`
+4. **ParserInitialized** — validates `ParserService` readiness
+5. **PerformSyntacticAnalysis** — parses token stream via `ParserService`
+6. **EmitParseResult** — assembles output payload with AST
+
+The parser service is injected into `ParserInitialized` and `PerformSyntacticAnalysis` events via the Tiferet DI container:
+
+```yaml
+# config.yml (attrs section)
+parser_service:
+  module_path: src.utils.parser
+  class_name: TiferetParser
+```
+
+
+## TokenStream Adapter
+
+PLY's `yacc.parser.parse()` expects a lexer-like object with a `.token()` method. `TokenStream` provides this adapter:
+
+```python
+stream = TokenStream(tokens)  # tokens = List[Dict[str, Any]]
+parser.parser.parse(lexer=stream)
+```
+
+`TokenStream` iterates over the token dictionaries and wraps each into a `PLYToken` object with `.type`, `.value`, `.lineno`, and `.lexpos` attributes that PLY expects.
+
+
+## AST Structure
+
+The parser produces a nested dict-based AST. Each node has a `type` key indicating its kind:
+
+- **`Module`** — root node containing a `groups` list
+- **`Group`** — `header` (artifact group token value) + `sections` list
+- **`Section`** — `header` + `annotations` list + `body` (ClassDef, FuncDef, or ImportBlock)
+- **`ClassDef`** — `name`, `bases`, `docstring`, `members` list
+- **`Member`** — `kind` (attribute/method/init), `annotations`, `body` (AttrDecl or MethodDef)
+- **`MethodDef`** — `name`, `params`, `return_type`, `decorator`, `docstring`, `body` (list of Snippets)
+- **`FuncDef`** — same shape as MethodDef but without `SELF` requirement
+- **`Snippet`** — `comment` (optional LINE_COMMENT) + `statements` list
+- **`Stmt`** — `tokens` (flat token sequence) + optional `block` (compound statement body)
+- **`Enclosed`** — `open`, `items`, `close` (matched bracket group)
+- **`ImportBlock`** — `statements` list of ImportStmt nodes
+- **`ImportStmt`** — `keyword` + `tokens`
+- **`AttrDecl`** — `name` + `type_annotation`
+- **`Annot`** — `kind` (OBSOLETE/TODO) + `text`
+- **`Decorator`** — `tokens` list
+- **`Body`** — `docstring` + `snippets` list
+
+### Example AST Fragment
+
+For a simple event class with one method:
+
+```yaml
+type: Module
+groups:
+  - type: Group
+    header: "# *** events"
+    sections:
+      - type: Section
+        header: "# ** event: add_error"
+        annotations: []
+        body:
+          type: ClassDef
+          name: AddError
+          bases: [DomainEvent]
+          docstring: "Command to add a new Error..."
+          members:
+            - type: Member
+              kind: method
+              annotations: []
+              body:
+                type: MethodDef
+                name: execute
+                params: [...]
+                return_type: null
+                decorator: null
+                docstring: "Add a new Error..."
+                body:
+                  - type: Snippet
+                    comment: "# Check if error exists."
+                    statements:
+                      - type: Stmt
+                        tokens: [...]
+                        block: null
+```
+
+
+## Error Handling
+
+The parser reports syntax errors via `p_error`, raising a `SyntaxError` with context about the unexpected token and expected artifact hierarchy structure. Domain events (`PerformSyntacticAnalysis`) wrap parsing in a `verify` call to produce structured `TiferetError` instances when the AST root is invalid.
+
+
+## Semantic Actions
+
+Semantic actions translate PLY productions into AST nodes. They are organized in `src/utils/parser.py` as module-level functions dispatched via the `_SEMANTIC_ACTIONS` dict:
+
+- **Tier 1 actions** — `_action_module`, `_action_group`, `_action_group_header`
+- **Tier 2 actions** — `_action_section`, `_action_section_annotated`, annotation builders
+- **Section body actions** — import block, class def, function def builders
+- **Tier 3 actions** — `_action_member`, `_action_member_annotated`, attribute/method builders
+- **Body/snippet actions** — body, snippet, and statement builders
+- **Token sequence actions** — token seq, enclosed, inner item handlers
+- **List helpers** — `_collect_list` (left-recursive accumulation), `_empty_list` (base case)
+
+String-based BNF rules from assets are wrapped by `_build_semantic_action`, which resolves the correct action from the dispatch table and sets `__doc__` to the production string (required by PLY).
+
+
+## Relationship to Other Utilities
+
+- **`TiferetLexer`** — produces the token stream consumed by `TiferetParser`
+- **`IndentInjector`** — injects synthetic `INDENT`/`DEDENT` tokens that the parser uses as block delimiters
+- **`ArtifactBlockParser`** — extracts artifact blocks from source files; the parser operates on the combined token stream from all extracted blocks
+- **`ScanOutputWriter`** — used by `EmitParseResult` to write the final payload (including AST) to file
+
+
+## Testing
+
+Parser utility tests live in `src/utils/tests/test_parser.py` (16 tests). Parser event tests live in `src/events/tests/test_parser.py` (9 tests).
+
+```bash
+# Run parser utility tests
+python -m pytest src/utils/tests/test_parser.py -v
+
+# Run parser event tests
+python -m pytest src/events/tests/test_parser.py -v
+```
+
+Tests use mock `ParserService` instances for event isolation and real `TiferetParser` instances for utility integration tests.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,10 +3,14 @@
 # *** exports
 
 # ** app
-from .events import DomainEvent, TiferetError, ExtractText, LexerInitialized, PerformLexicalAnalysis, EmitScanResult
-from .interfaces import LexerService
-from .utils import TiferetLexer
+from .events import (
+    DomainEvent, TiferetError,
+    ExtractText, LexerInitialized, PerformLexicalAnalysis, EmitScanResult,
+    ParserInitialized, PerformSyntacticAnalysis, SyntacticAnalysisCompleted,
+)
+from .interfaces import LexerService, ParserService
+from .utils import TiferetLexer, TiferetParser
 
 # *** version
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'


### PR DESCRIPTION
## Summary

Completes issue #38 — updates all project documentation and bumps the version to 0.3.0 to reflect the syntactic parser implementation.

## Changes

- **New:** `docs/guides/utils/parser.md` — parser utility guide covering `TiferetParser`, `ParserService`, dynamic grammar loading, AST structure, pipeline integration, semantic actions, and testing
- **Updated:** `src/__init__.py` — version bumped to `0.3.0`, added exports for `ParserInitialized`, `PerformSyntacticAnalysis`, `SyntacticAnalysisCompleted`, `ParserService`, and `TiferetParser`
- **Updated:** `README.md` — project structure tree with all parser files, usage section, test counts (121), version references, doc links
- **Updated:** `AGENTS.md` — two bounded contexts architecture, dual pipeline descriptions (`scan.event` + `parse.event`), parser key files, structure tree, test counts, dependencies

## Verification

- All 121 tests pass (`python3 -m pytest src/ -v`)
- No code changes to parser implementation, events, or utilities
- `src/events/__init__.py` already had parser exports from prior work — no change needed

Closes #38

---

[Warp conversation](https://app.warp.dev/conversation/cf93162d-638a-4150-be70-33be671749c4)

Co-Authored-By: Oz <oz-agent@warp.dev>