### PR TITLE
Parser Pipeline End-to-End Fixes (v0.3.1)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -50,8 +50,6 @@ features:
         - attribute_id: perform_syntactic_analysis_event
           name: Parse token stream into AST
           data_key: ast
-          params:
-            tokens: analysis_result.tokens
         - attribute_id: syntactic_analysis_completed_event
           name: Finalize syntactic analysis result
           data_key: syntactic_result
@@ -76,8 +74,6 @@ features:
         - attribute_id: perform_syntactic_analysis_event
           name: Parse token stream into AST
           data_key: ast
-          params:
-            tokens: analysis_result.tokens
         - attribute_id: emit_parse_result_event
           name: Assemble and emit parse result
 
@@ -147,6 +143,33 @@ cli:
           - name_or_flags:
               - --metrics-format
             description: "Metrics rendering format: yaml, json, or text."
+    parse:
+      event:
+        group_key: parse
+        key: event
+        name: Parse Event Command
+        description: Perform syntactic parsing on a Tiferet event source file.
+        args:
+          - name_or_flags:
+              - source_file
+            description: Path to the Python source file to parse.
+          - name_or_flags:
+              - -o
+              - --output
+            description: Path to output YAML/JSON file.
+          - name_or_flags:
+              - --format
+            description: "Output format: yaml, json, console, or auto."
+          - name_or_flags:
+              - -x
+              - --extract
+            description: Comma-separated artifact names to extract.
+          - name_or_flags:
+              - --summary-only
+            description: Output only metrics/summary (no token list).
+          - name_or_flags:
+              - --with-metrics
+            description: Include detailed lexical metrics section.
 
 interfaces:
   compiler:

--- a/src/assets/lexer.py
+++ b/src/assets/lexer.py
@@ -251,7 +251,7 @@ _python_keywords = {
 
 # ** constant: artifact_imports_start
 def ARTIFACT_IMPORTS_START(self, t):
-    r'\#\s*\*{3}\s+imports\s*'
+    r'\#\s*\*{3}\s+imports[^\S\n]*'
     return t
 
 # ** constant: artifact_import_group

--- a/src/events/parser.py
+++ b/src/events/parser.py
@@ -20,20 +20,20 @@ class ParserInitialized(DomainEvent):
     is properly instantiated before syntactic analysis.
     '''
 
-    # * attribute: parser
-    parser: ParserService
+    # * attribute: parser_service
+    parser_service: ParserService
 
     # * init
-    def __init__(self, parser: ParserService):
+    def __init__(self, parser_service: ParserService):
         '''
         Initialize with injected parser service.
 
-        :param parser: The parser service for syntactic analysis.
-        :type parser: ParserService
+        :param parser_service: The parser service for syntactic analysis.
+        :type parser_service: ParserService
         '''
 
         # Set the parser service dependency.
-        self.parser = parser
+        self.parser_service = parser_service
 
     # * method: execute
     @DomainEvent.parameters_required([])
@@ -49,13 +49,13 @@ class ParserInitialized(DomainEvent):
 
         # Verify the parser service is not None.
         self.verify(
-            expression=self.parser is not None,
+            expression=self.parser_service is not None,
             error_code='PARSER_NOT_INITIALIZED',
             message='TiferetParser service failed to initialize',
         )
 
         # Return the validated parser service.
-        return self.parser
+        return self.parser_service
 
 
 # ** event: perform_syntactic_analysis
@@ -65,40 +65,43 @@ class PerformSyntacticAnalysis(DomainEvent):
     tokenized input using the injected ParserService.
     '''
 
-    # * attribute: parser
-    parser: ParserService
+    # * attribute: parser_service
+    parser_service: ParserService
 
     # * init
-    def __init__(self, parser: ParserService):
+    def __init__(self, parser_service: ParserService):
         '''
         Initialize with injected parser service.
 
-        :param parser: The parser service for syntactic analysis.
-        :type parser: ParserService
+        :param parser_service: The parser service for syntactic analysis.
+        :type parser_service: ParserService
         '''
 
         # Set the parser service dependency.
-        self.parser = parser
+        self.parser_service = parser_service
 
     # * method: execute
-    @DomainEvent.parameters_required(['tokens'])
+    @DomainEvent.parameters_required(['analysis_result'])
     def execute(self,
-            tokens: List[Dict[str, Any]],
+            analysis_result: Dict[str, Any],
             **kwargs,
         ) -> Dict[str, Any]:
         '''
         Parse token stream and produce structured AST.
 
-        :param tokens: Token stream from PerformLexicalAnalysis (post-IndentInjector).
-        :type tokens: List[Dict[str, Any]]
+        :param analysis_result: Analysis result dict from PerformLexicalAnalysis containing tokens.
+        :type analysis_result: Dict[str, Any]
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         :return: AST dict with Module root.
         :rtype: Dict[str, Any]
         '''
 
+        # Extract tokens from the analysis result.
+        tokens = analysis_result['tokens']
+
         # Execute syntactic parsing via the injected parser service.
-        ast = self.parser.parse(tokens)
+        ast = self.parser_service.parse(tokens)
 
         # Validate the AST root structure is a Module.
         self.verify(

--- a/src/events/scan.py
+++ b/src/events/scan.py
@@ -63,11 +63,18 @@ class ExtractText(DomainEvent):
         # Extract the imports block.
         imports_block = ArtifactBlockParser.extract_imports_block(lines)
 
+        # Extract the group header (e.g. # *** events).
+        group_header = ArtifactBlockParser.extract_group_header(lines)
+
         # Extract artifact blocks for the given group type.
         blocks = ArtifactBlockParser.extract_artifact_blocks(lines, group_type)
 
         # Apply extract filter if specified (imports are always included).
         blocks = ArtifactBlockParser.filter_blocks(blocks, extract_ids)
+
+        # Prepend the group header if found.
+        if group_header:
+            blocks.insert(0, group_header)
 
         # Prepend the imports block if found.
         if imports_block:

--- a/src/events/tests/test_parser.py
+++ b/src/events/tests/test_parser.py
@@ -95,7 +95,7 @@ def test_parser_initialized_success(mock_parser_service: ParserService) -> None:
     # Execute the ParserInitialized event.
     result = DomainEvent.handle(
         ParserInitialized,
-        dependencies={'parser': mock_parser_service},
+        dependencies={'parser_service': mock_parser_service},
     )
 
     # Assert the parser service is returned.
@@ -112,7 +112,7 @@ def test_parser_initialized_none_service() -> None:
     with pytest.raises(TiferetError):
         DomainEvent.handle(
             ParserInitialized,
-            dependencies={'parser': None},
+            dependencies={'parser_service': None},
         )
 
 # *** tests — PerformSyntacticAnalysis
@@ -140,8 +140,8 @@ def test_perform_syntactic_analysis_success(
     # Execute via DomainEvent.handle with injected dependency.
     result = DomainEvent.handle(
         PerformSyntacticAnalysis,
-        dependencies={'parser': mock_parser_service},
-        tokens=sample_tokens,
+        dependencies={'parser_service': mock_parser_service},
+        analysis_result={'tokens': sample_tokens},
     )
 
     # Assert the AST structure is correct.
@@ -164,11 +164,11 @@ def test_perform_syntactic_analysis_missing_tokens(
     :type mock_parser_service: ParserService
     '''
 
-    # Attempt without tokens.
+    # Attempt without analysis_result.
     with pytest.raises(TiferetError):
         DomainEvent.handle(
             PerformSyntacticAnalysis,
-            dependencies={'parser': mock_parser_service},
+            dependencies={'parser_service': mock_parser_service},
         )
 
 
@@ -193,8 +193,8 @@ def test_perform_syntactic_analysis_invalid_ast(
     with pytest.raises(TiferetError):
         DomainEvent.handle(
             PerformSyntacticAnalysis,
-            dependencies={'parser': mock_parser_service},
-            tokens=sample_tokens,
+            dependencies={'parser_service': mock_parser_service},
+            analysis_result={'tokens': sample_tokens},
         )
 
 
@@ -219,8 +219,8 @@ def test_perform_syntactic_analysis_none_ast(
     with pytest.raises(TiferetError):
         DomainEvent.handle(
             PerformSyntacticAnalysis,
-            dependencies={'parser': mock_parser_service},
-            tokens=sample_tokens,
+            dependencies={'parser_service': mock_parser_service},
+            analysis_result={'tokens': sample_tokens},
         )
 
 # *** tests — SyntacticAnalysisCompleted

--- a/src/events/tests/test_scan.py
+++ b/src/events/tests/test_scan.py
@@ -133,14 +133,15 @@ def test_extract_text_success(sample_source_file: str) -> None:
         source_file=sample_source_file,
     )
 
-    # Assert imports block plus two event blocks were extracted.
-    assert len(result) == 3
+    # Assert imports block, group header, plus two event blocks were extracted.
+    assert len(result) == 4
     assert result[0]['name'] == '__imports__'
-    assert result[1]['name'] == 'sample_event'
-    assert result[2]['name'] == 'another_event'
+    assert result[1]['name'] == '__group_header__'
+    assert result[2]['name'] == 'sample_event'
+    assert result[3]['name'] == 'another_event'
     assert result[0]['text'] is not None
     assert '# *** imports' in result[0]['text']
-    assert len(result[1]['text']) > 0
+    assert len(result[2]['text']) > 0
 
 
 # ** test: extract_text_with_filter
@@ -159,10 +160,11 @@ def test_extract_text_with_filter(sample_source_file: str) -> None:
         extract='sample_event',
     )
 
-    # Assert imports block plus the filtered block were returned.
-    assert len(result) == 2
+    # Assert imports block, group header, plus the filtered block were returned.
+    assert len(result) == 3
     assert result[0]['name'] == '__imports__'
-    assert result[1]['name'] == 'sample_event'
+    assert result[1]['name'] == '__group_header__'
+    assert result[2]['name'] == 'sample_event'
 
 
 # ** test: extract_text_missing_source_file_param

--- a/src/utils/artifact.py
+++ b/src/utils/artifact.py
@@ -74,6 +74,41 @@ class ArtifactBlockParser:
         # Return None if no imports section found.
         return None
 
+    # * method: extract_group_header (static)
+    @staticmethod
+    def extract_group_header(
+            lines: List[str],
+        ) -> Optional[Dict[str, Any]]:
+        '''
+        Locate and extract the first non-imports top-level group header
+        (e.g. ``# *** events``) from source lines.
+
+        :param lines: The source file lines.
+        :type lines: List[str]
+        :return: A block dict with name, line_start, line_end, text,
+                 and length_chars, or None if not found.
+        :rtype: Optional[Dict[str, Any]]
+        '''
+
+        # Build patterns for top-level sections.
+        top_level_pattern = re.compile(r'^\s*#\s*\*{3}\s+(\S+)')
+
+        # Walk lines to find the first non-imports group header.
+        for i, line in enumerate(lines):
+            match = top_level_pattern.match(line)
+            if match and match.group(1) != 'imports':
+                text = line
+                return {
+                    'name': '__group_header__',
+                    'line_start': i,
+                    'line_end': i + 1,
+                    'text': text,
+                    'length_chars': len(text),
+                }
+
+        # Return None if no group header found.
+        return None
+
     # * method: extract_artifact_blocks (static)
     @staticmethod
     def extract_artifact_blocks(

--- a/src/utils/indent.py
+++ b/src/utils/indent.py
@@ -12,13 +12,14 @@ from typing import List, Dict, Any
 class IndentInjector:
     '''
     Post-tokenization utility that injects INDENT and DEDENT tokens
-    into a PLY token stream within method and init artifact member bodies.
+    into a PLY token stream within class bodies and method/init
+    artifact member bodies.
 
-    Enters method-body mode after an ARTIFACT_MEMBER token whose value
-    matches ``# * method:`` or ``# * init``. Tracks indentation depth
-    via a column stack, guarded by parenthesis depth so multi-line
-    function signatures are ignored. Exits on the next artifact comment
-    at the same or higher structural level.
+    Class body mode is entered after a ``CLASS ... COLON NEWLINE``
+    sequence. Method-body mode is entered after an ARTIFACT_MEMBER
+    token whose value matches ``# * method:`` or ``# * init``.
+    Tracks indentation depth via a column stack, guarded by
+    parenthesis depth so multi-line signatures are ignored.
     '''
 
     # * method: inject (static)
@@ -30,7 +31,7 @@ class IndentInjector:
         :param tokens: Flat token list produced by the PLY lexer.
         :type tokens: List[Dict[str, Any]]
         :return: Token list with INDENT and DEDENT tokens injected
-                 at method-body indentation boundaries.
+                 at class-body and method-body indentation boundaries.
         :rtype: List[Dict[str, Any]]
         '''
 
@@ -46,11 +47,27 @@ class IndentInjector:
             'ARTIFACT_IMPORT_GROUP',
         }
 
+        # Annotation token types that close a method body only when
+        # indent_stack is non-empty (distinguishing post-body annotations
+        # from preamble annotations).
+        annotation_exits = {'OBSOLETE', 'TODO'}
+
+        # Structural tokens that close class bodies.
+        class_exits = {
+            'ARTIFACT_SECTION',
+            'ARTIFACT_START',
+            'ARTIFACT_IMPORTS_START',
+        }
+
         result = []
         in_method_body = False
+        in_class_body = False
         member_col = None
+        class_col = None
         indent_stack = []
+        class_indent_stack = []
         paren_depth = 0
+        saw_class = False
 
         i = 0
         while i < len(tokens):
@@ -62,10 +79,15 @@ class IndentInjector:
             elif tok['type'] in ('RPAREN', 'RBRACK', 'RBRACE'):
                 paren_depth = max(0, paren_depth - 1)
 
-            # Artifact member token — close any open body, optionally open new one.
+            # Detect CLASS token to watch for class body entry.
+            if tok['type'] == 'CLASS':
+                saw_class = True
+                class_col = tok['column']
+
+            # Artifact member token — close any open method body, optionally open new one.
             if tok['type'] == 'ARTIFACT_MEMBER':
 
-                # Flush remaining DEDENTs for the closing body.
+                # Flush remaining DEDENTs for the closing method body.
                 while indent_stack:
                     result.append({
                         'type': 'DEDENT', 'value': '',
@@ -73,18 +95,20 @@ class IndentInjector:
                     })
                     indent_stack.pop()
 
-                # Reset body state.
+                # Reset method body state.
                 in_method_body = False
                 member_col = None
                 paren_depth = 0
 
-                # Enter body mode if this member is a method or init.
+                # Enter method body mode if this member is a method or init.
                 if method_pattern.search(tok['value']):
                     in_method_body = True
                     member_col = tok['column']
 
-            # Section or start token — always close any open body.
-            elif tok['type'] in ('ARTIFACT_SECTION', 'ARTIFACT_START', 'ARTIFACT_IMPORTS_START'):
+            # Section or start token — close any open method body and class body.
+            elif tok['type'] in class_exits:
+
+                # Close method body first.
                 while indent_stack:
                     result.append({
                         'type': 'DEDENT', 'value': '',
@@ -94,6 +118,63 @@ class IndentInjector:
                 in_method_body = False
                 member_col = None
                 paren_depth = 0
+
+                # Close class body.
+                while class_indent_stack:
+                    result.append({
+                        'type': 'DEDENT', 'value': '',
+                        'line': tok['line'], 'column': tok['column'],
+                    })
+                    class_indent_stack.pop()
+                in_class_body = False
+                class_col = None
+                saw_class = False
+
+            # Handle annotation tokens — close method body only when inside one.
+            elif tok['type'] in annotation_exits and indent_stack:
+                while indent_stack:
+                    result.append({
+                        'type': 'DEDENT', 'value': '',
+                        'line': tok['line'], 'column': tok['column'],
+                    })
+                    indent_stack.pop()
+                in_method_body = False
+                member_col = None
+
+            # Class body INDENT injection after CLASS...COLON NEWLINE.
+            if in_class_body and tok['type'] == 'NEWLINE' and not in_method_body and paren_depth == 0:
+                result.append(tok)
+                i += 1
+
+                # Consume any consecutive newlines.
+                while i < len(tokens) and tokens[i]['type'] == 'NEWLINE':
+                    result.append(tokens[i])
+                    i += 1
+
+                if i < len(tokens):
+                    next_tok = tokens[i]
+                    next_col = next_tok['column']
+
+                    # Structural boundary closes class body.
+                    if next_tok['type'] in class_exits:
+                        while class_indent_stack:
+                            result.append({
+                                'type': 'DEDENT', 'value': '',
+                                'line': next_tok['line'], 'column': next_tok['column'],
+                            })
+                            class_indent_stack.pop()
+                        in_class_body = False
+                        class_col = None
+
+                    # First class body line — inject INDENT.
+                    elif not class_indent_stack and class_col is not None and next_col > class_col:
+                        class_indent_stack.append(next_col)
+                        result.append({
+                            'type': 'INDENT', 'value': '',
+                            'line': next_tok['line'], 'column': next_col,
+                        })
+
+                continue
 
             # Inject INDENT/DEDENT after each newline inside a method body.
             if in_method_body and tok['type'] == 'NEWLINE' and paren_depth == 0:
@@ -109,8 +190,19 @@ class IndentInjector:
                     next_tok = tokens[i]
                     next_col = next_tok['column']
 
-                    # Next artifact comment closes the body.
+                    # Next artifact comment closes the method body.
                     if next_tok['type'] in exits_body:
+                        while indent_stack:
+                            result.append({
+                                'type': 'DEDENT', 'value': '',
+                                'line': next_tok['line'], 'column': next_tok['column'],
+                            })
+                            indent_stack.pop()
+                        in_method_body = False
+                        member_col = None
+
+                    # Annotation after method body closes it.
+                    elif next_tok['type'] in annotation_exits and indent_stack:
                         while indent_stack:
                             result.append({
                                 'type': 'DEDENT', 'value': '',
@@ -154,6 +246,11 @@ class IndentInjector:
 
                 continue
 
+            # Detect COLON after CLASS to enter class body on the next NEWLINE.
+            if saw_class and tok['type'] == 'COLON' and paren_depth == 0:
+                saw_class = False
+                in_class_body = True
+
             result.append(tok)
             i += 1
 
@@ -165,6 +262,14 @@ class IndentInjector:
                 'line': last_line, 'column': 0,
             })
             indent_stack.pop()
+
+        # Close any class body still open at end of stream.
+        while class_indent_stack:
+            result.append({
+                'type': 'DEDENT', 'value': '',
+                'line': last_line, 'column': 0,
+            })
+            class_indent_stack.pop()
 
         # Return the enriched token stream.
         return result


### PR DESCRIPTION
## Summary

Resolves six interrelated defects preventing the `parse event` CLI pipeline from functioning end-to-end.

Closes #45

## Changes

1. **DI name mismatch** — Renamed `parser` → `parser_service` in `ParserInitialized` and `PerformSyntacticAnalysis` to match the `config.yml` container attribute name.
2. **Broken params dot-path** — Changed `PerformSyntacticAnalysis.execute` to accept `analysis_result: Dict` directly and extract `tokens` internally. Removed `params` sections from both pipeline definitions in `config.yml`.
3. **Missing group header extraction** — Added `ArtifactBlockParser.extract_group_header()` static method and wired it into `ExtractText.execute()` to emit the `# ***` group header block between imports and event blocks.
4. **Lexer regex consuming newlines** — Replaced trailing `\s*` with `[^\S\n]*` in the `ARTIFACT_IMPORTS_START` rule to preserve `NEWLINE` tokens.
5. **IndentInjector class body + annotation support** — Added `CLASS...COLON NEWLINE` class body `INDENT`/`DEDENT` tracking. Added `annotation_exits` set (`OBSOLETE`, `TODO`) to close method bodies at annotation boundaries.
6. **Missing parse event CLI command** — Registered `parse event` in the `config.yml` CLI section with matching arguments.

## Testing

All 121 unit tests pass (`python -m pytest src/ -v`).

---

[Warp conversation](https://app.warp.dev/conversation/b77051c1-d5c2-4bb6-9b45-59757745cb8d)

Co-Authored-By: Oz <oz-agent@warp.dev>